### PR TITLE
ci(infra): add issue templates, PR template, and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,33 @@
+# CODEOWNERS — fill in real GitHub handles before enabling
+# "Require review from Code Owners" in branch protection.
+
+# Default owner — receives review requests for all files not matched below
+# * @<infra-owner>
+
+# Frontend
+# /src/routes/                    @<frontend-owner>
+# /src/lib/components/            @<frontend-owner>
+
+# Backend
+# /src/lib/server/                @<backend-owner>
+
+# Auth — security-sensitive, always requires both the auth owner and a second reviewer
+# /src/lib/server/auth/           @<auth-owner> @<security-reviewer>
+
+# Game
+# /game-server/                   @<game-owner>
+# /src/lib/game/                  @<game-owner>
+
+# Database
+# /prisma/                        @<db-owner>
+
+# Shared package
+# /packages/game-shared/          @<backend-owner> @<game-owner>
+
+# i18n
+# /messages/                      @<frontend-owner>
+
+# Infrastructure — all .github/ changes require infra review
+# /.github/                       @<infra-owner>
+# /docker/                        @<infra-owner>
+# /compose.yaml                   @<infra-owner>

--- a/.github/ISSUE_TEMPLATE/chore.yaml
+++ b/.github/ISSUE_TEMPLATE/chore.yaml
@@ -1,0 +1,32 @@
+name: "chore — Tooling / dependencies"
+description: "Dependency updates, config files, tooling maintenance."
+labels: ["type: chore", "status: todo"]
+body:
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - frontend
+        - backend
+        - auth
+        - game
+        - db
+        - shared
+        - infra
+        - i18n
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      value: "- [ ] "
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/ci.yaml
+++ b/.github/ISSUE_TEMPLATE/ci.yaml
@@ -1,0 +1,33 @@
+name: "ci — CI / workflows"
+description: "CI pipelines, GitHub Actions, workflow changes."
+labels: ["type: ci", "status: todo"]
+body:
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - frontend
+        - backend
+        - auth
+        - game
+        - db
+        - shared
+        - infra
+        - i18n
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What pipeline or workflow is being changed and why.
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      value: "- [ ] "
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/docs.yaml
+++ b/.github/ISSUE_TEMPLATE/docs.yaml
@@ -1,0 +1,33 @@
+name: "docs — Documentation"
+description: Documentation only.
+labels: ["type: docs", "status: todo"]
+body:
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - frontend
+        - backend
+        - auth
+        - game
+        - db
+        - shared
+        - infra
+        - i18n
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What documentation is being added or changed.
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      value: "- [ ] "
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feat.yaml
+++ b/.github/ISSUE_TEMPLATE/feat.yaml
@@ -1,0 +1,35 @@
+name: "feat — New feature"
+description: New functionality visible in the product.
+labels: ["type: feat", "status: todo"]
+body:
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Which area of the codebase does this change affect?
+      options:
+        - frontend
+        - backend
+        - auth
+        - game
+        - db
+        - shared
+        - infra
+        - i18n
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs to be done and why.
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      description: Break the work into checkable steps.
+      value: "- [ ] "
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/fix.yaml
+++ b/.github/ISSUE_TEMPLATE/fix.yaml
@@ -1,0 +1,33 @@
+name: "fix — Bug fix"
+description: Corrects unintended behavior.
+labels: ["type: fix", "status: todo"]
+body:
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - frontend
+        - backend
+        - auth
+        - game
+        - db
+        - shared
+        - infra
+        - i18n
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is the bug and what is the expected behavior.
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      value: "- [ ] "
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/perf.yaml
+++ b/.github/ISSUE_TEMPLATE/perf.yaml
@@ -1,0 +1,33 @@
+name: "perf — Performance"
+description: "Performance improvement, particularly game loop and rendering."
+labels: ["type: perf", "status: todo"]
+body:
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - frontend
+        - backend
+        - auth
+        - game
+        - db
+        - shared
+        - infra
+        - i18n
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is slow, what is the target improvement, and how it will be measured.
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      value: "- [ ] "
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/refactor.yaml
+++ b/.github/ISSUE_TEMPLATE/refactor.yaml
@@ -1,0 +1,33 @@
+name: "refactor — Code restructure"
+description: Code restructured with no behavior change.
+labels: ["type: refactor", "status: todo"]
+body:
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - frontend
+        - backend
+        - auth
+        - game
+        - db
+        - shared
+        - infra
+        - i18n
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is being restructured and why.
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      value: "- [ ] "
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/security.yaml
+++ b/.github/ISSUE_TEMPLATE/security.yaml
@@ -1,0 +1,33 @@
+name: "security — Security"
+description: "Auth, JWT, OAuth, 2FA, session, input validation."
+labels: ["type: security", "status: todo"]
+body:
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - frontend
+        - backend
+        - auth
+        - game
+        - db
+        - shared
+        - infra
+        - i18n
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is the vulnerability or security concern and what is the fix.
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      value: "- [ ] "
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/style.yaml
+++ b/.github/ISSUE_TEMPLATE/style.yaml
@@ -1,0 +1,33 @@
+name: "style — Formatting pass"
+description: "Formatting, linting, Prettier/ESLint passes — zero logic change."
+labels: ["type: style", "status: todo"]
+body:
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - frontend
+        - backend
+        - auth
+        - game
+        - db
+        - shared
+        - infra
+        - i18n
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is being formatted and why now.
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      value: "- [ ] "
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/test.yaml
+++ b/.github/ISSUE_TEMPLATE/test.yaml
@@ -1,0 +1,33 @@
+name: "test — Tests"
+description: Adding or updating tests.
+labels: ["type: test", "status: todo"]
+body:
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - frontend
+        - backend
+        - auth
+        - game
+        - db
+        - shared
+        - infra
+        - i18n
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What is being tested and what coverage is added.
+    validations:
+      required: true
+  - type: textarea
+    id: tasks
+    attributes:
+      label: Tasks
+      value: "- [ ] "
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## What
+
+<!-- Summary of the change. -->
+
+Closes #
+
+## How
+
+<!-- Approach taken. Anything the reviewer should pay particular attention to. -->
+
+## Checklist
+
+- [ ] Tests added or updated
+- [ ] Documentation updated if needed
+- [ ] No unintended side effects


### PR DESCRIPTION
Adds the 10 issue templates (one per `type:` label), the PR body template, and CODEOWNERS.

Issue templates auto-apply the correct `type:` label and `status: todo` on creation, and
expose a scope dropdown that `automation-label-issue.js` will read once workflows are live.

Closes #10