### PR TITLE
ci(infra): add script stubs

### DIFF
--- a/.github/scripts/automation/automation-label-issue.js
+++ b/.github/scripts/automation/automation-label-issue.js
@@ -1,0 +1,13 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+const log = require('./utils/log')('automation-label-issue');
+// const utils = require('./automation-utils')(core.getInput('token'), github.context);
+
+async function run() {
+  log.info('stub — not yet implemented');
+}
+
+run().catch((err) => {
+  log.error(err.message);
+  process.exit(1);
+});

--- a/.github/scripts/automation/automation-label-pr.js
+++ b/.github/scripts/automation/automation-label-pr.js
@@ -1,0 +1,13 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+const log = require('./utils/log')('automation-label-pr');
+// const utils = require('./automation-utils')(core.getInput('token'), github.context);
+
+async function run() {
+  log.info('stub — not yet implemented');
+}
+
+run().catch((err) => {
+  log.error(err.message);
+  process.exit(1);
+});

--- a/.github/scripts/automation/automation-state-branch.js
+++ b/.github/scripts/automation/automation-state-branch.js
@@ -1,0 +1,13 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+const log = require('./utils/log')('automation-state-branch');
+// const utils = require('./automation-utils')(core.getInput('token'), github.context);
+
+async function run() {
+  log.info('stub — not yet implemented');
+}
+
+run().catch((err) => {
+  log.error(err.message);
+  process.exit(1);
+});

--- a/.github/scripts/automation/automation-state-pr-merge.js
+++ b/.github/scripts/automation/automation-state-pr-merge.js
@@ -1,0 +1,13 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+const log = require('./utils/log')('automation-state-pr-merge');
+// const utils = require('./automation-utils')(core.getInput('token'), github.context);
+
+async function run() {
+  log.info('stub — not yet implemented');
+}
+
+run().catch((err) => {
+  log.error(err.message);
+  process.exit(1);
+});

--- a/.github/scripts/automation/automation-state-pr-open.js
+++ b/.github/scripts/automation/automation-state-pr-open.js
@@ -1,0 +1,13 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+const log = require('./utils/log')('automation-state-pr-open');
+// const utils = require('./automation-utils')(core.getInput('token'), github.context);
+
+async function run() {
+  log.info('stub — not yet implemented');
+}
+
+run().catch((err) => {
+  log.error(err.message);
+  process.exit(1);
+});

--- a/.github/scripts/automation/automation-utils.js
+++ b/.github/scripts/automation/automation-utils.js
@@ -1,0 +1,52 @@
+const { getOctokit } = require('@actions/github');
+
+/**
+ * Shared GitHub API helpers for automation scripts.
+ * Usage: const utils = require('./automation-utils')(token, context);
+ *
+ * @param {string} token   - GitHub token from secrets.GITHUB_TOKEN
+ * @param {object} context - @actions/github context object
+ */
+module.exports = (token, context) => {
+  const octokit = getOctokit(token);
+  const { owner, repo } = context.repo;
+
+  /**
+   * Returns issue numbers linked to a PR via closing keywords
+   * (Closes #N, Fixes #N, Resolves #N — GitHub's own engine, case-insensitive).
+   */
+  async function getClosingIssues(prNumber) {
+    // TODO: implement
+    // gh api graphql -f query='
+    //   query($owner: String!, $repo: String!, $pr: Int!) {
+    //     repository(owner: $owner, name: $repo) {
+    //       pullRequest(number: $pr) {
+    //         closingIssuesReferences(first: 10) {
+    //           nodes { number }
+    //         }
+    //       }
+    //     }
+    //   }'
+    throw new Error('stub — not yet implemented');
+  }
+
+  /** Applies a label to an issue or PR. No-op if the label does not exist. */
+  async function applyLabel(issueNumber, label) {
+    // TODO: implement
+    throw new Error('stub — not yet implemented');
+  }
+
+  /** Removes a label from an issue or PR. No-op if the label is not present. */
+  async function removeLabel(issueNumber, label) {
+    // TODO: implement
+    throw new Error('stub — not yet implemented');
+  }
+
+  /** Returns true if the label exists on the repository. */
+  async function labelExists(label) {
+    // TODO: implement
+    throw new Error('stub — not yet implemented');
+  }
+
+  return { getClosingIssues, applyLabel, removeLabel, labelExists };
+};

--- a/.github/scripts/ci/ci-lint-eslint.sh
+++ b/.github/scripts/ci/ci-lint-eslint.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="ci-lint-eslint"
+source "$(dirname "$0")/../utils/log.sh"
+
+log_info "stub — not yet implemented"
+exit 0

--- a/.github/scripts/ci/ci-lint-prettier.sh
+++ b/.github/scripts/ci/ci-lint-prettier.sh
@@ -1,0 +1,9 @@
+
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="ci-lint-prettier"
+source "$(dirname "$0")/../utils/log.sh"
+
+log_info "stub — not yet implemented"
+exit 0

--- a/.github/scripts/ci/ci-test-e2e.sh
+++ b/.github/scripts/ci/ci-test-e2e.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="ci-test-e2e"
+source "$(dirname "$0")/../utils/log.sh"
+
+log_info "stub — not yet implemented"
+exit 0

--- a/.github/scripts/ci/ci-test-integration.sh
+++ b/.github/scripts/ci/ci-test-integration.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="ci-test-integration"
+source "$(dirname "$0")/../utils/log.sh"
+
+log_info "stub — not yet implemented"
+exit 0

--- a/.github/scripts/ci/ci-test-unit.sh
+++ b/.github/scripts/ci/ci-test-unit.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="ci-test-unit"
+source "$(dirname "$0")/../utils/log.sh"
+
+log_info "stub — not yet implemented"
+exit 0

--- a/.github/scripts/ci/ci-typecheck-frontend.sh
+++ b/.github/scripts/ci/ci-typecheck-frontend.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="ci-typecheck-frontend"
+source "$(dirname "$0")/../utils/log.sh"
+
+log_info "stub — not yet implemented"
+exit 0

--- a/.github/scripts/ci/ci-typecheck-game-server.sh
+++ b/.github/scripts/ci/ci-typecheck-game-server.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="ci-typecheck-game-server.sh"
+source "$(dirname "$0")/../utils/log.sh"
+
+log_info "stub — not yet implemented"
+exit 0

--- a/.github/scripts/utils/log.js
+++ b/.github/scripts/utils/log.js
@@ -1,0 +1,15 @@
+const core = require('@actions/core');
+
+/**
+ * Logger factory for automation scripts.
+ * Usage: const log = require('./utils/log')('script-name');
+ *
+ * @param {string} scriptName - Appears as [scriptName] prefix in every log line.
+ */
+module.exports = (scriptName) => ({
+  info:  (msg) => core.info(`[${scriptName}] ${msg}`),
+  warn:  (msg) => core.warning(`[${scriptName}] ${msg}`),
+  error: (msg) => core.error(`[${scriptName}] ${msg}`),
+  group: (msg) => core.startGroup(`[${scriptName}] ${msg}`),
+  end:   ()    => core.endGroup(),
+});

--- a/.github/scripts/utils/log.sh
+++ b/.github/scripts/utils/log.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Logging utilities for CI scripts.
+# Usage: set SCRIPT_NAME before sourcing this file.
+#
+#   SCRIPT_NAME="ci-lint-eslint"
+#   source "$(dirname "$0")/../utils/log.sh"
+
+log_info()  { echo "::notice:: [${SCRIPT_NAME}] $*"; }
+log_warn()  { echo "::warning:: [${SCRIPT_NAME}] $*"; }
+log_error() { echo "::error:: [${SCRIPT_NAME}] $*"; }
+log_group() { echo "::group:: [${SCRIPT_NAME}] $*"; }
+log_end()   { echo "::endgroup::"; }


### PR DESCRIPTION
Adds all `.github/scripts/` files.

`utils/log.sh` and `utils/log.js` are complete implementations.
All `ci/` and `automation/` scripts are stubs — correct filenames and `SCRIPT_NAME`
declarations, exit 0, ready to be replaced when each workflow is implemented.

Closes #11

Needs issue #10 and PR #13 merged first.