### PR TITLE
ci(infra): add workflow stubs

### DIFF
--- a/.github/workflows/automation-label-issue.yaml
+++ b/.github/workflows/automation-label-issue.yaml
@@ -1,0 +1,14 @@
+name: automation-label-issue
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub — not yet implemented"

--- a/.github/workflows/automation-label-pr.yaml
+++ b/.github/workflows/automation-label-pr.yaml
@@ -1,0 +1,14 @@
+name: automation-label-pr
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub — not yet implemented"

--- a/.github/workflows/automation-state-branch.yaml
+++ b/.github/workflows/automation-state-branch.yaml
@@ -1,0 +1,13 @@
+name: automation-state-branch
+
+on:
+  create:
+
+permissions:
+  issues: write
+
+jobs:
+  state:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub — not yet implemented"

--- a/.github/workflows/automation-state-pr.yaml
+++ b/.github/workflows/automation-state-pr.yaml
@@ -1,0 +1,14 @@
+name: automation-state-pr
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, closed]
+
+permissions:
+  issues: write
+
+jobs:
+  state:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub — not yet implemented"

--- a/.github/workflows/ci-docker-build.yaml
+++ b/.github/workflows/ci-docker-build.yaml
@@ -1,0 +1,20 @@
+name: ci-docker-build
+
+on:
+  push:
+    branches: ['ci/**', 'infra/**']
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-docker-build-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub — not yet implemented"

--- a/.github/workflows/ci-docker-push.yaml
+++ b/.github/workflows/ci-docker-push.yaml
@@ -1,0 +1,14 @@
+name: ci-docker-push
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  docker-push:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub — not yet implemented"

--- a/.github/workflows/ci-lint-eslint.yaml
+++ b/.github/workflows/ci-lint-eslint.yaml
@@ -1,0 +1,20 @@
+name: ci-lint-eslint
+
+on:
+  push:
+    branches: ['feat/**', 'fix/**', 'chore/**']
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-lint-eslint-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint-eslint:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub — not yet implemented"

--- a/.github/workflows/ci-lint-pr-title.yaml
+++ b/.github/workflows/ci-lint-pr-title.yaml
@@ -1,0 +1,19 @@
+name: ci-lint-pr-title
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, edited]
+
+concurrency:
+  group: ci-lint-pr-title-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub — not yet implemented"

--- a/.github/workflows/ci-lint-prettier.yaml
+++ b/.github/workflows/ci-lint-prettier.yaml
@@ -1,0 +1,20 @@
+name: ci-lint-prettier
+
+on:
+  push:
+    branches: ['feat/**', 'fix/**', 'chore/**']
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-lint-prettier-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  lint-prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub — not yet implemented"

--- a/.github/workflows/ci-test-e2e.yaml
+++ b/.github/workflows/ci-test-e2e.yaml
@@ -1,0 +1,19 @@
+name: ci-test-e2e
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+
+concurrency:
+  group: ci-test-e2e-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub — not yet implemented"

--- a/.github/workflows/ci-test-integration.yaml
+++ b/.github/workflows/ci-test-integration.yaml
@@ -1,0 +1,19 @@
+name: ci-test-integration
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize]
+
+concurrency:
+  group: ci-test-integration-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub — not yet implemented"

--- a/.github/workflows/ci-test-unit.yaml
+++ b/.github/workflows/ci-test-unit.yaml
@@ -1,0 +1,20 @@
+name: ci-test-unit
+
+on:
+  push:
+    branches: ['feat/**', 'fix/**', 'chore/**']
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-test-unit-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub — not yet implemented"

--- a/.github/workflows/ci-typecheck-frontent.yaml
+++ b/.github/workflows/ci-typecheck-frontent.yaml
@@ -1,0 +1,20 @@
+name: ci-typecheck-frontend
+
+on:
+  push:
+    branches: ['feat/**', 'fix/**', 'chore/**']
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-typecheck-frontend-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck-frontend:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub — not yet implemented"

--- a/.github/workflows/ci-typecheck-game-server.yaml
+++ b/.github/workflows/ci-typecheck-game-server.yaml
@@ -1,0 +1,20 @@
+name: ci-typecheck-game-server
+
+on:
+  push:
+    branches: ['feat/**', 'fix/**', 'chore/**']
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-typecheck-game-server-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  typecheck-game-server:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "stub — not yet implemented"


### PR DESCRIPTION
Adds all 14 workflow stubs with real `on:` triggers and placeholder steps.

Opening this PR registers every workflow name in GitHub Actions, making them
selectable as required status checks in branch protection settings. Workflow
logic will be filled in incrementally as each script is implemented.

Closes #12 

Needs issues #10 #11 and PRs #13 #14 merged first.