### PR TITLE
ci(infra): implement automation scripts

### DIFF
--- a/.github/scripts/automation/automation-label-issue.js
+++ b/.github/scripts/automation/automation-label-issue.js
@@ -1,10 +1,52 @@
-const core = require('@actions/core');
+const core   = require('@actions/core');
 const github = require('@actions/github');
-const log = require('./utils/log')('automation-label-issue');
-// const utils = require('./automation-utils')(core.getInput('token'), github.context);
+const log    = require('../utils/log')('automation-label-issue');
+const utils  = require('./automation-utils')(core.getInput('token'), github.context);
+
+const SCOPE_MAP = {
+  frontend: 'scope: frontend',
+  backend:  'scope: backend',
+  auth:     'scope: auth',
+  game:     'scope: game',
+  db:       'scope: db',
+  shared:   'scope: shared',
+  infra:    'scope: infra',
+  i18n:     'scope: i18n',
+};
+
+function parseScopeFromBody(body) {
+  if (!body) return null;
+  const match = body.match(/###\s+Scope\s*\n+([^\n#]+)/);
+  if (!match) return null;
+  return match[1].trim().toLowerCase();
+}
 
 async function run() {
-  log.info('stub — not yet implemented');
+  const issue = github.context.payload.issue;
+  if (!issue) {
+    log.warn('No issue in payload, skipping');
+    return;
+  }
+
+  log.group(`Issue #${issue.number}`);
+
+  const scopeValue = parseScopeFromBody(issue.body);
+  if (!scopeValue) {
+    log.warn('No scope section found in issue body, skipping');
+    log.end();
+    return;
+  }
+
+  const label = SCOPE_MAP[scopeValue];
+  if (!label) {
+    log.warn(`Unknown scope value "${scopeValue}", skipping`);
+    log.end();
+    return;
+  }
+
+  await utils.applyLabel(issue.number, label);
+  log.info(`Applied "${label}"`);
+  log.end();
 }
 
 run().catch((err) => {

--- a/.github/scripts/automation/automation-label-pr.js
+++ b/.github/scripts/automation/automation-label-pr.js
@@ -1,10 +1,57 @@
-const core = require('@actions/core');
+const core   = require('@actions/core');
 const github = require('@actions/github');
-const log = require('./utils/log')('automation-label-pr');
-// const utils = require('./automation-utils')(core.getInput('token'), github.context);
+const log    = require('../utils/log')('automation-label-pr');
+const utils  = require('./automation-utils')(core.getInput('token'), github.context);
+
+const TITLE_REGEX  = /^(\w+)(?:\((\w+)\))?!?:\s.+/;
+const VALID_TYPES  = ['feat', 'fix', 'refactor', 'style', 'test', 'ci', 'chore', 'docs', 'perf', 'security'];
+const VALID_SCOPES = ['frontend', 'backend', 'auth', 'game', 'db', 'shared', 'infra', 'i18n'];
 
 async function run() {
-  log.info('stub — not yet implemented');
+  const pr = github.context.payload.pull_request;
+  if (!pr) {
+    log.warn('No pull request in payload, skipping');
+    return;
+  }
+
+  log.group(`PR #${pr.number}: "${pr.title}"`);
+
+  const match = pr.title.match(TITLE_REGEX);
+  if (!match) {
+    log.warn('Title does not match conventional commit format, skipping');
+    log.end();
+    return;
+  }
+
+  const [, rawType, rawScope] = match;
+  const type  = rawType.toLowerCase();
+  const scope = rawScope ? rawScope.toLowerCase() : null;
+
+  const current = await utils.getCurrentLabels(pr.number);
+  const stale   = current.filter(l => l.startsWith('type: ') || l.startsWith('scope: '));
+
+  for (const label of stale) {
+    await utils.removeLabel(pr.number, label);
+    log.info(`Removed stale "${label}"`);
+  }
+
+  if (VALID_TYPES.includes(type)) {
+    await utils.applyLabel(pr.number, `type: ${type}`);
+    log.info(`Applied "type: ${type}"`);
+  } else {
+    log.warn(`Unknown type "${type}", skipping`);
+  }
+
+  if (scope) {
+    if (VALID_SCOPES.includes(scope)) {
+      await utils.applyLabel(pr.number, `scope: ${scope}`);
+      log.info(`Applied "scope: ${scope}"`);
+    } else {
+      log.warn(`Unknown scope "${scope}", skipping`);
+    }
+  }
+
+  log.end();
 }
 
 run().catch((err) => {

--- a/.github/scripts/automation/automation-state-branch.js
+++ b/.github/scripts/automation/automation-state-branch.js
@@ -1,10 +1,36 @@
-const core = require('@actions/core');
+const core   = require('@actions/core');
 const github = require('@actions/github');
-const log = require('./utils/log')('automation-state-branch');
-// const utils = require('./automation-utils')(core.getInput('token'), github.context);
+const log    = require('../utils/log')('automation-state-branch');
+const utils  = require('./automation-utils')(core.getInput('token'), github.context);
+
+const BRANCH_PATTERN = /^\w+\/(\d+)-/;
 
 async function run() {
-  log.info('stub — not yet implemented');
+  const payload = github.context.payload;
+
+  if (payload.ref_type !== 'branch') {
+    log.info(`ref_type is "${payload.ref_type}", skipping`);
+    return;
+  }
+
+  const branchName = payload.ref;
+  const match      = branchName.match(BRANCH_PATTERN);
+
+  if (!match) {
+    log.info(`"${branchName}" does not match naming pattern, skipping`);
+    return;
+  }
+
+  const issueNumber = parseInt(match[1], 10);
+  log.group(`"${branchName}" -> issue #${issueNumber}`);
+
+  await utils.removeLabel(issueNumber, 'status: todo');
+  log.info('Removed "status: todo"');
+
+  await utils.applyLabel(issueNumber, 'status: in progress');
+  log.info('Applied "status: in progress"');
+
+  log.end();
 }
 
 run().catch((err) => {

--- a/.github/scripts/automation/automation-state-pr-merge.js
+++ b/.github/scripts/automation/automation-state-pr-merge.js
@@ -1,10 +1,36 @@
-const core = require('@actions/core');
+const core   = require('@actions/core');
 const github = require('@actions/github');
-const log = require('./utils/log')('automation-state-pr-merge');
-// const utils = require('./automation-utils')(core.getInput('token'), github.context);
+const log    = require('../utils/log')('automation-state-pr-merge');
+const utils  = require('./automation-utils')(core.getInput('token'), github.context);
 
 async function run() {
-  log.info('stub — not yet implemented');
+  const pr = github.context.payload.pull_request;
+  if (!pr) {
+    log.warn('No pull request in payload, skipping');
+    return;
+  }
+
+  if (!pr.merged) {
+    log.info('PR closed without merging, skipping');
+    return;
+  }
+
+  log.group(`PR #${pr.number} merged`);
+
+  const issueNumbers = await utils.getClosingIssues(pr.number);
+  if (issueNumbers.length === 0) {
+    log.warn('No linked issues found via closingIssuesReferences, skipping');
+    log.end();
+    return;
+  }
+
+  for (const number of issueNumbers) {
+    await utils.removeLabel(number, 'status: in review');
+    await utils.applyLabel(number, 'status: done');
+    log.info(`Issue #${number}: in review -> done`);
+  }
+
+  log.end();
 }
 
 run().catch((err) => {

--- a/.github/scripts/automation/automation-state-pr-open.js
+++ b/.github/scripts/automation/automation-state-pr-open.js
@@ -1,10 +1,31 @@
-const core = require('@actions/core');
+const core   = require('@actions/core');
 const github = require('@actions/github');
-const log = require('./utils/log')('automation-state-pr-open');
-// const utils = require('./automation-utils')(core.getInput('token'), github.context);
+const log    = require('../utils/log')('automation-state-pr-open');
+const utils  = require('./automation-utils')(core.getInput('token'), github.context);
 
 async function run() {
-  log.info('stub — not yet implemented');
+  const pr = github.context.payload.pull_request;
+  if (!pr) {
+    log.warn('No pull request in payload, skipping');
+    return;
+  }
+
+  log.group(`PR #${pr.number} opened/ready`);
+
+  const issueNumbers = await utils.getClosingIssues(pr.number);
+  if (issueNumbers.length === 0) {
+    log.warn('No linked issues found via closingIssuesReferences, skipping');
+    log.end();
+    return;
+  }
+
+  for (const number of issueNumbers) {
+    await utils.removeLabel(number, 'status: in progress');
+    await utils.applyLabel(number, 'status: in review');
+    log.info(`Issue #${number}: in progress -> in review`);
+  }
+
+  log.end();
 }
 
 run().catch((err) => {

--- a/.github/scripts/automation/automation-utils.js
+++ b/.github/scripts/automation/automation-utils.js
@@ -1,52 +1,89 @@
 const { getOctokit } = require('@actions/github');
 
+const CLOSING_ISSUES_QUERY = `
+  query($owner: String!, $repo: String!, $pr: Int!) {
+    repository(owner: $owner, name: $repo) {
+      pullRequest(number: $pr) {
+        closingIssuesReferences(first: 10) {
+          nodes { number }
+        }
+      }
+    }
+  }
+`;
+
 /**
  * Shared GitHub API helpers for automation scripts.
- * Usage: const utils = require('./automation-utils')(token, context);
+ * Usage: const utils = require('./automation-utils')(core.getInput('token'), github.context);
  *
- * @param {string} token   - GitHub token from secrets.GITHUB_TOKEN
+ * @param {string} token   - GitHub token from core.getInput('token')
  * @param {object} context - @actions/github context object
  */
 module.exports = (token, context) => {
-  const octokit = getOctokit(token);
+  const octokit         = getOctokit(token);
   const { owner, repo } = context.repo;
 
   /**
-   * Returns issue numbers linked to a PR via closing keywords
-   * (Closes #N, Fixes #N, Resolves #N — GitHub's own engine, case-insensitive).
+   * Returns issue numbers linked to a PR via closing keywords.
+   * Uses GitHub's own engine — handles Closes/Fixes/Resolves, case-insensitive.
    */
   async function getClosingIssues(prNumber) {
-    // TODO: implement
-    // gh api graphql -f query='
-    //   query($owner: String!, $repo: String!, $pr: Int!) {
-    //     repository(owner: $owner, name: $repo) {
-    //       pullRequest(number: $pr) {
-    //         closingIssuesReferences(first: 10) {
-    //           nodes { number }
-    //         }
-    //       }
-    //     }
-    //   }'
-    throw new Error('stub — not yet implemented');
+    const result = await octokit.graphql(CLOSING_ISSUES_QUERY, {
+      owner,
+      repo,
+      pr: prNumber,
+    });
+    return result.repository.pullRequest.closingIssuesReferences.nodes.map(n => n.number);
   }
 
-  /** Applies a label to an issue or PR. No-op if the label does not exist. */
+  /** Applies a label to an issue or PR. */
   async function applyLabel(issueNumber, label) {
-    // TODO: implement
-    throw new Error('stub — not yet implemented');
+    await octokit.rest.issues.addLabels({
+      owner,
+      repo,
+      issue_number: issueNumber,
+      labels: [label],
+    });
   }
 
-  /** Removes a label from an issue or PR. No-op if the label is not present. */
+  /**
+   * Removes a label from an issue or PR.
+   * No-op if the label is not present (404 is swallowed).
+   */
   async function removeLabel(issueNumber, label) {
-    // TODO: implement
-    throw new Error('stub — not yet implemented');
+    try {
+      await octokit.rest.issues.removeLabel({
+        owner,
+        repo,
+        issue_number: issueNumber,
+        name: label,
+      });
+    } catch (err) {
+      if (err.status === 404) return;
+      throw err;
+    }
   }
 
-  /** Returns true if the label exists on the repository. */
+  /** Returns true if the label exists in the repository. */
   async function labelExists(label) {
-    // TODO: implement
-    throw new Error('stub — not yet implemented');
+    try {
+      await octokit.rest.issues.getLabel({ owner, repo, name: label });
+      return true;
+    } catch (err) {
+      if (err.status === 404) return false;
+      throw err;
+    }
   }
 
-  return { getClosingIssues, applyLabel, removeLabel, labelExists };
+  /** Returns all label names currently applied to an issue or PR. */
+  async function getCurrentLabels(issueNumber) {
+    const { data } = await octokit.rest.issues.listLabelsOnIssue({
+      owner,
+      repo,
+      issue_number: issueNumber,
+    });
+    return data.map(l => l.name);
+  }
+
+  return { getClosingIssues, applyLabel, removeLabel, labelExists, getCurrentLabels };
 };

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "dependencies": {
+    "@actions/core":   "^1.10.1",
+    "@actions/github": "^6.0.0"
+  }
+}

--- a/.github/scripts/pnpm-lock.yaml
+++ b/.github/scripts/pnpm-lock.yaml
@@ -1,0 +1,214 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@actions/core':
+        specifier: ^1.10.1
+        version: 1.11.1
+      '@actions/github':
+        specifier: ^6.0.0
+        version: 6.0.1
+
+packages:
+
+  '@actions/core@1.11.1':
+    resolution: {integrity: sha512-hXJCSrkwfA46Vd9Z3q4cpEpHB1rL5NG04+/rbqW9d3+CSvtB1tYe8UTpAlixa1vj0m/ULglfEK2UKxMGxCxv5A==}
+
+  '@actions/exec@1.1.1':
+    resolution: {integrity: sha512-+sCcHHbVdk93a0XT19ECtO/gIXoxvdsgQLzb2fE2/5sIZmWQuluYyjPQtrtTHdU1YzTZ7bAPN4sITq2xi1679w==}
+
+  '@actions/github@6.0.1':
+    resolution: {integrity: sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==}
+
+  '@actions/http-client@2.2.3':
+    resolution: {integrity: sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==}
+
+  '@actions/io@1.1.3':
+    resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
+
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
+  '@octokit/auth-token@4.0.0':
+    resolution: {integrity: sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/core@5.2.2':
+    resolution: {integrity: sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==}
+    engines: {node: '>= 18'}
+
+  '@octokit/endpoint@9.0.6':
+    resolution: {integrity: sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/graphql@7.1.1':
+    resolution: {integrity: sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==}
+    engines: {node: '>= 18'}
+
+  '@octokit/openapi-types@20.0.0':
+    resolution: {integrity: sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==}
+
+  '@octokit/openapi-types@24.2.0':
+    resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
+
+  '@octokit/plugin-paginate-rest@9.2.2':
+    resolution: {integrity: sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+
+  '@octokit/plugin-rest-endpoint-methods@10.4.1':
+    resolution: {integrity: sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '5'
+
+  '@octokit/request-error@5.1.1':
+    resolution: {integrity: sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==}
+    engines: {node: '>= 18'}
+
+  '@octokit/request@8.4.1':
+    resolution: {integrity: sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/types@12.6.0':
+    resolution: {integrity: sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==}
+
+  '@octokit/types@13.10.0':
+    resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
+
+  before-after-hook@2.2.3:
+    resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
+
+  deprecation@2.3.1:
+    resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
+  universal-user-agent@6.0.1:
+    resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+snapshots:
+
+  '@actions/core@1.11.1':
+    dependencies:
+      '@actions/exec': 1.1.1
+      '@actions/http-client': 2.2.3
+
+  '@actions/exec@1.1.1':
+    dependencies:
+      '@actions/io': 1.1.3
+
+  '@actions/github@6.0.1':
+    dependencies:
+      '@actions/http-client': 2.2.3
+      '@octokit/core': 5.2.2
+      '@octokit/plugin-paginate-rest': 9.2.2(@octokit/core@5.2.2)
+      '@octokit/plugin-rest-endpoint-methods': 10.4.1(@octokit/core@5.2.2)
+      '@octokit/request': 8.4.1
+      '@octokit/request-error': 5.1.1
+      undici: 5.29.0
+
+  '@actions/http-client@2.2.3':
+    dependencies:
+      tunnel: 0.0.6
+      undici: 5.29.0
+
+  '@actions/io@1.1.3': {}
+
+  '@fastify/busboy@2.1.1': {}
+
+  '@octokit/auth-token@4.0.0': {}
+
+  '@octokit/core@5.2.2':
+    dependencies:
+      '@octokit/auth-token': 4.0.0
+      '@octokit/graphql': 7.1.1
+      '@octokit/request': 8.4.1
+      '@octokit/request-error': 5.1.1
+      '@octokit/types': 13.10.0
+      before-after-hook: 2.2.3
+      universal-user-agent: 6.0.1
+
+  '@octokit/endpoint@9.0.6':
+    dependencies:
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/graphql@7.1.1':
+    dependencies:
+      '@octokit/request': 8.4.1
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/openapi-types@20.0.0': {}
+
+  '@octokit/openapi-types@24.2.0': {}
+
+  '@octokit/plugin-paginate-rest@9.2.2(@octokit/core@5.2.2)':
+    dependencies:
+      '@octokit/core': 5.2.2
+      '@octokit/types': 12.6.0
+
+  '@octokit/plugin-rest-endpoint-methods@10.4.1(@octokit/core@5.2.2)':
+    dependencies:
+      '@octokit/core': 5.2.2
+      '@octokit/types': 12.6.0
+
+  '@octokit/request-error@5.1.1':
+    dependencies:
+      '@octokit/types': 13.10.0
+      deprecation: 2.3.1
+      once: 1.4.0
+
+  '@octokit/request@8.4.1':
+    dependencies:
+      '@octokit/endpoint': 9.0.6
+      '@octokit/request-error': 5.1.1
+      '@octokit/types': 13.10.0
+      universal-user-agent: 6.0.1
+
+  '@octokit/types@12.6.0':
+    dependencies:
+      '@octokit/openapi-types': 20.0.0
+
+  '@octokit/types@13.10.0':
+    dependencies:
+      '@octokit/openapi-types': 24.2.0
+
+  before-after-hook@2.2.3: {}
+
+  deprecation@2.3.1: {}
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  tunnel@0.0.6: {}
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  universal-user-agent@6.0.1: {}
+
+  wrappy@1.0.2: {}

--- a/.github/workflows/automation-label-issue.yaml
+++ b/.github/workflows/automation-label-issue.yaml
@@ -26,7 +26,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install automation dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-workspace
         working-directory: .github/scripts
 
       - name: Apply scope label

--- a/.github/workflows/automation-label-issue.yaml
+++ b/.github/workflows/automation-label-issue.yaml
@@ -4,6 +4,10 @@ on:
   issues:
     types: [opened]
 
+concurrency:
+  group: automation-label-issue-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 permissions:
   issues: write
 
@@ -11,4 +15,21 @@ jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "stub — not yet implemented"
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install automation dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .github/scripts
+
+      - name: Apply scope label
+        run: node .github/scripts/automation/automation-label-issue.js
+        env:
+          INPUT_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/automation-label-pr.yaml
+++ b/.github/workflows/automation-label-pr.yaml
@@ -4,11 +4,33 @@ on:
   pull_request:
     types: [opened, edited]
 
+concurrency:
+  group: automation-label-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
+  issues:        write
   pull-requests: write
 
 jobs:
   label:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "stub — not yet implemented"
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install automation dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .github/scripts
+
+      - name: Apply type and scope labels
+        run: node .github/scripts/automation/automation-label-pr.js
+        env:
+          INPUT_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/automation-label-pr.yaml
+++ b/.github/workflows/automation-label-pr.yaml
@@ -2,7 +2,7 @@ name: automation-label-pr
 
 on:
   pull_request:
-    types: [opened, edited]
+    types: [opened, reopened, edited]
 
 concurrency:
   group: automation-label-pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/automation-label-pr.yaml
+++ b/.github/workflows/automation-label-pr.yaml
@@ -27,7 +27,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install automation dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-workspace
         working-directory: .github/scripts
 
       - name: Apply type and scope labels

--- a/.github/workflows/automation-state-branch.yaml
+++ b/.github/workflows/automation-state-branch.yaml
@@ -25,7 +25,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install automation dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-workspace
         working-directory: .github/scripts
 
       - name: Transition issue to in progress

--- a/.github/workflows/automation-state-branch.yaml
+++ b/.github/workflows/automation-state-branch.yaml
@@ -3,6 +3,10 @@ name: automation-state-branch
 on:
   create:
 
+concurrency:
+  group: automation-state-branch-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   issues: write
 
@@ -10,4 +14,21 @@ jobs:
   state:
     runs-on: ubuntu-latest
     steps:
-      - run: echo "stub — not yet implemented"
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install automation dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .github/scripts
+
+      - name: Transition issue to in progress
+        run: node .github/scripts/automation/automation-state-branch.js
+        env:
+          INPUT_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/automation-state-pr.yaml
+++ b/.github/workflows/automation-state-pr.yaml
@@ -5,7 +5,7 @@ on:
     types: [opened, reopened, ready_for_review, closed]
 
 concurrency:
-  group: automation-state-pr-${{ github.event.pull_request.number }}
+  group: automation-state-pr-${{ github.event.pull_request.number }}-${{ github.event.action }}
   cancel-in-progress: true
 
 permissions:
@@ -13,7 +13,10 @@ permissions:
 
 jobs:
   on-open:
-    if: github.event.action == 'opened' || github.event.action == 'ready_for_review'
+    if: >-
+      github.event.action == 'opened' ||
+      github.event.action == 'reopened' ||
+      github.event.action == 'ready_for_review' 
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/automation-state-pr.yaml
+++ b/.github/workflows/automation-state-pr.yaml
@@ -2,7 +2,7 @@ name: automation-state-pr
 
 on:
   pull_request:
-    types: [opened, ready_for_review, closed]
+    types: [opened, reopened, ready_for_review, closed]
 
 concurrency:
   group: automation-state-pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/automation-state-pr.yaml
+++ b/.github/workflows/automation-state-pr.yaml
@@ -27,7 +27,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install automation dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-workspace
         working-directory: .github/scripts
 
       - name: Transition linked issues to in review
@@ -50,7 +50,7 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Install automation dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-workspace
         working-directory: .github/scripts
 
       - name: Transition linked issues to done

--- a/.github/workflows/automation-state-pr.yaml
+++ b/.github/workflows/automation-state-pr.yaml
@@ -4,11 +4,56 @@ on:
   pull_request:
     types: [opened, ready_for_review, closed]
 
+concurrency:
+  group: automation-state-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   issues: write
 
 jobs:
-  state:
+  on-open:
+    if: github.event.action == 'opened' || github.event.action == 'ready_for_review'
     runs-on: ubuntu-latest
     steps:
-      - run: echo "stub — not yet implemented"
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install automation dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .github/scripts
+
+      - name: Transition linked issues to in review
+        run: node .github/scripts/automation/automation-state-pr-open.js
+        env:
+          INPUT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  on-merge:
+    if: github.event.action == 'closed' && github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+
+      - name: Install automation dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: .github/scripts
+
+      - name: Transition linked issues to done
+        run: node .github/scripts/automation/automation-state-pr-merge.js
+        env:
+          INPUT_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What

Implements all GitHub Actions automation scripts for label management and issue state transitions.

Closes #16

## How

Each script is a standalone Node.js CJS module invoked directly by its workflow via `run:`. All scripts share the same factory-based `log.js` and `automation-utils.js` helpers for consistent output formatting and GitHub API access.

- `automation-label-issue` — parses the scope dropdown from the issue form body, applies the matching `scope:` label on issue open
- `automation-label-pr` — parses type and scope from the PR title, replaces stale `type:`/`scope:` labels on open and edit
- `automation-state-branch` — extracts the issue number from the branch name, transitions `status: todo` → `status: in progress` on branch creation
- `automation-state-pr` — transitions linked issues to `status: in review` on PR open and `status: done` on merge, using GraphQL `closingIssuesReferences` instead of body parsing

A scoped `package.json` and `pnpm-lock.yaml` live in `.github/scripts/` to isolate CJS dependencies from the root ESM workspace.

## Checklist

- [ ] No unintended side effects