### PR TITLE
chore(infra): exclude generated files from prettier

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -7,3 +7,8 @@ bun.lockb
 
 # Miscellaneous
 /static/
+
+# Generated
+prisma/migrations/
+.svelte-kit/
+build/


### PR DESCRIPTION
## What

Adds `prisma/migrations/` and `.svelte-kit/` to `.prettierignore`.
Both are generated — formatting them produces false diffs and noise in PRs.

Closes #33 

## How

Straightforward ignore rule additions. No config logic changed.

## Checklist

- [x] No unintended side effects