### PR TITLE
feat(game): add chat in battle

### DIFF
--- a/server/rooms/TankRoom.cts
+++ b/server/rooms/TankRoom.cts
@@ -13,6 +13,8 @@ import {
 import { PROJECTILE_TYPES } from '../../src/lib/game/shared/projectileTypes.js';
 import type { GameState } from '../../src/lib/game/shared/state/GameState.js';
 import type { TankState } from '../../src/lib/game/shared/state/TankState.js';
+// import chat handler
+import { registerChatHandler } from '../../src/lib/game/colyseus/handlers/chatHandler.ts';
 
 const SCENE_WIDTH = 1280;
 const SCENE_HEIGHT = 720;
@@ -75,6 +77,8 @@ export class TankRoom extends Room<{ state: GameRoomState }> {
 		});
 
 		this.setSimulationInterval((dt) => this.tick(dt), 1000 / 60);
+		// register chat handler
+		registerChatHandler(this, (client) => this.getPlayerIndex(client));
 	}
 
 	onJoin(client: Client) {

--- a/src/lib/game/client/view/ChatInput.ts
+++ b/src/lib/game/client/view/ChatInput.ts
@@ -1,0 +1,91 @@
+import { COLOR_STRINGS } from '$lib/game/phaser/colors';
+
+export type OnSendCallback = (text: string) => void;
+
+export class ChatInput {
+	private input: HTMLInputElement;
+	private container: HTMLElement;
+	private isOpen = false;
+	private onSend: OnSendCallback;
+	private scene: Phaser.Scene;
+	private canOpen = true;
+	
+	constructor(scene: Phaser.Scene, onSend: OnSendCallback) {
+		this.scene = scene;
+		this.onSend = onSend;
+
+		this.container = document.createElement('div');
+		Object.assign(this.container.style, {
+			position: 'absolute',
+			bottom: '120px',
+			left: '50%',
+			transform: 'translateX(-50%)',
+			display: 'none',
+			zIndex: '999',
+		});
+
+		this.input = document.createElement('input');
+		this.input.type = 'text';
+		this.input.maxLength = 80;
+		this.input.placeholder = 'Say something...';
+		Object.assign(this.input.style, {
+			width: '320px',
+			padding: '8px 14px',
+			fontSize: '14px',
+			background: COLOR_STRINGS.bg,
+			color: COLOR_STRINGS.white,
+			border: '2px solid COLOR_STRINGS.neonGlow',
+			borderRadius: '8px',
+			outline: 'none',
+			caretColor: COLOR_STRINGS.neonGlow,
+		});
+		this.container.appendChild(this.input);
+
+		const gameParent = document.getElementById('game-container') ?? document.body;
+		gameParent.style.position = 'relative';
+		gameParent.appendChild(this.container);
+
+		// Prevent game input when typing
+		this.input.addEventListener('focus', () => {
+			this.scene.input.keyboard!.disableGlobalCapture();
+		});
+		this.input.addEventListener('blur', () => {
+			this.scene.input.keyboard!.enableGlobalCapture();
+		});
+		// Handle Enter and Escape keys
+		this.input.addEventListener('keydown', (e) => {
+			e.stopPropagation();
+			if (e.key === 'Enter') this.submit();
+			if (e.key === 'Escape') this.close();
+		});
+	}
+
+open() {
+    if (this.isOpen || !this.canOpen) return; // if already open or recently blocked
+    this.isOpen = true;
+    this.input.value = '';
+    this.container.style.display = 'block';
+    setTimeout(() => this.input.focus(), 30);
+}
+
+block(duration: number) {
+    this.canOpen = false;
+    setTimeout(() => { this.canOpen = true; }, duration);
+}
+
+	private close() {
+		this.isOpen = false;
+		this.container.style.display = 'none';
+		this.input.blur();
+	}
+
+	private submit() {
+		const text = this.input.value.trim();
+		this.close();
+		if (text) this.onSend(text);
+	}
+
+	destroy() {
+		this.container.remove();
+	}
+}

--- a/src/lib/game/client/view/ChatInput.ts
+++ b/src/lib/game/client/view/ChatInput.ts
@@ -9,7 +9,7 @@ export class ChatInput {
 	private onSend: OnSendCallback;
 	private scene: Phaser.Scene;
 	private canOpen = true;
-	
+
 	constructor(scene: Phaser.Scene, onSend: OnSendCallback) {
 		this.scene = scene;
 		this.onSend = onSend;
@@ -21,7 +21,7 @@ export class ChatInput {
 			left: '50%',
 			transform: 'translateX(-50%)',
 			display: 'none',
-			zIndex: '999',
+			zIndex: '999'
 		});
 
 		this.input = document.createElement('input');
@@ -37,7 +37,7 @@ export class ChatInput {
 			border: '2px solid COLOR_STRINGS.neonGlow',
 			borderRadius: '8px',
 			outline: 'none',
-			caretColor: COLOR_STRINGS.neonGlow,
+			caretColor: COLOR_STRINGS.neonGlow
 		});
 		this.container.appendChild(this.input);
 
@@ -60,18 +60,20 @@ export class ChatInput {
 		});
 	}
 
-open() {
-    if (this.isOpen || !this.canOpen) return; // if already open or recently blocked
-    this.isOpen = true;
-    this.input.value = '';
-    this.container.style.display = 'block';
-    setTimeout(() => this.input.focus(), 30);
-}
+	open() {
+		if (this.isOpen || !this.canOpen) return; // if already open or recently blocked
+		this.isOpen = true;
+		this.input.value = '';
+		this.container.style.display = 'block';
+		setTimeout(() => this.input.focus(), 30);
+	}
 
-block(duration: number) {
-    this.canOpen = false;
-    setTimeout(() => { this.canOpen = true; }, duration);
-}
+	block(duration: number) {
+		this.canOpen = false;
+		setTimeout(() => {
+			this.canOpen = true;
+		}, duration);
+	}
 
 	private close() {
 		this.isOpen = false;

--- a/src/lib/game/colyseus/handlers/chatHandler.ts
+++ b/src/lib/game/colyseus/handlers/chatHandler.ts
@@ -2,28 +2,28 @@ import type { Room, Client } from 'colyseus';
 import { CHAT_BUBBLE_DURATION } from '$lib/game/shared/chatConfig';
 
 export function registerChatHandler(
-    room: Room,
-    getPlayerIndex: (client: Client) => number | undefined
+	room: Room,
+	getPlayerIndex: (client: Client) => number | undefined
 ) {
-    const lastMessage = new Map<string, number>(); // anti-spam
+	const lastMessage = new Map<string, number>(); // anti-spam
 
-    room.onMessage('chat', (client: Client, data: { text: string }) => {
-    try {
-        const playerIndex = getPlayerIndex(client);
-        if (playerIndex === undefined) return;
+	room.onMessage('chat', (client: Client, data: { text: string }) => {
+		try {
+			const playerIndex = getPlayerIndex(client);
+			if (playerIndex === undefined) return;
 
-        const now = Date.now();
-        const last = lastMessage.get(client.sessionId) ?? 0;
-        if (now - last < CHAT_BUBBLE_DURATION) return;
+			const now = Date.now();
+			const last = lastMessage.get(client.sessionId) ?? 0;
+			if (now - last < CHAT_BUBBLE_DURATION) return;
 
-        const text = String(data.text).trim().slice(0, 80);
-        if (!text) return;
+			const text = String(data.text).trim().slice(0, 80);
+			if (!text) return;
 
-        lastMessage.set(client.sessionId, now);
+			lastMessage.set(client.sessionId, now);
 
-        room.broadcast('chat', { playerIndex, text });
-    } catch (err) {
-        console.error('[chatHandler] error:', err);
-    }
-});
+			room.broadcast('chat', { playerIndex, text });
+		} catch (err) {
+			console.error('[chatHandler] error:', err);
+		}
+	});
 }

--- a/src/lib/game/colyseus/handlers/chatHandler.ts
+++ b/src/lib/game/colyseus/handlers/chatHandler.ts
@@ -1,0 +1,29 @@
+import type { Room, Client } from 'colyseus';
+import { CHAT_BUBBLE_DURATION } from '$lib/game/shared/chatConfig';
+
+export function registerChatHandler(
+    room: Room,
+    getPlayerIndex: (client: Client) => number | undefined
+) {
+    const lastMessage = new Map<string, number>(); // anti-spam
+
+    room.onMessage('chat', (client: Client, data: { text: string }) => {
+    try {
+        const playerIndex = getPlayerIndex(client);
+        if (playerIndex === undefined) return;
+
+        const now = Date.now();
+        const last = lastMessage.get(client.sessionId) ?? 0;
+        if (now - last < CHAT_BUBBLE_DURATION) return;
+
+        const text = String(data.text).trim().slice(0, 80);
+        if (!text) return;
+
+        lastMessage.set(client.sessionId, now);
+
+        room.broadcast('chat', { playerIndex, text });
+    } catch (err) {
+        console.error('[chatHandler] error:', err);
+    }
+});
+}

--- a/src/lib/game/phaser/scenes/gameScene.ts
+++ b/src/lib/game/phaser/scenes/gameScene.ts
@@ -96,6 +96,12 @@ export default class GameScene extends Scene {
 	private readonly fuelBarW = 200;
 	private readonly fuelBarH = 18;
 
+	// bubble chat
+	private speechBubbles!: [SpeechBubble, SpeechBubble];
+	// chat input
+	private chatInput!: ChatInput;
+	private chatKey!: Input.Keyboard.Key;
+
 	private keys!: {
 		p1Left: Input.Keyboard.Key;
 		p1Right: Input.Keyboard.Key;

--- a/src/lib/game/phaser/scenes/gameScene.ts
+++ b/src/lib/game/phaser/scenes/gameScene.ts
@@ -383,6 +383,11 @@ export default class GameScene extends Scene {
 			});
 
 			this.statusText.setText('Waiting for Player 2...');
+			//Chat server handler
+			room.onMessage('chat', (data: { playerIndex: number; text: string }) => {
+		    const tank = this.localGameData!.tanks[data.playerIndex];
+		    this.speechBubbles[data.playerIndex].setText(data.text, tank);
+			});
 		} catch (err) {
 			this.statusText.setText('Connection failed.\nCheck the game server is running.');
 			console.error(err);
@@ -410,7 +415,6 @@ export default class GameScene extends Scene {
     	// chat init
     	this.chatInput?.destroy();
 		this.chatInput = new ChatInput(this, (text) => {
-			console.log('[client] envoi chat:', text);
     		this.room!.send('chat', { text });
 			this.chatInput.block(CHAT_BUBBLE_DURATION);
 		});

--- a/src/lib/game/phaser/scenes/gameScene.ts
+++ b/src/lib/game/phaser/scenes/gameScene.ts
@@ -11,6 +11,10 @@ import { Client, Room } from '@colyseus/sdk';
 import type { GameRoomState } from '../../colyseus/schema/GameRoomState';
 import { COLORS, COLOR_STRINGS } from '../colors';
 import { EventBus } from '../EventBus';
+// Chat input and bubble component
+import { SpeechBubble } from '$lib/game/client/view/SpeechBubble';
+import { ChatInput } from '$lib/game/client/view/ChatInput';
+import { CHAT_BUBBLE_DURATION } from '$lib/game/shared/chatConfig';
 
 const PLAYER_NAMES = ['Player 1', 'Player 2'];
 const COLYSEUS_URL =

--- a/src/lib/game/phaser/scenes/gameScene.ts
+++ b/src/lib/game/phaser/scenes/gameScene.ts
@@ -385,8 +385,8 @@ export default class GameScene extends Scene {
 			this.statusText.setText('Waiting for Player 2...');
 			//Chat server handler
 			room.onMessage('chat', (data: { playerIndex: number; text: string }) => {
-		    const tank = this.localGameData!.tanks[data.playerIndex];
-		    this.speechBubbles[data.playerIndex].setText(data.text, tank);
+				const tank = this.localGameData!.tanks[data.playerIndex];
+				this.speechBubbles[data.playerIndex].setText(data.text, tank);
 			});
 		} catch (err) {
 			this.statusText.setText('Connection failed.\nCheck the game server is running.');
@@ -408,14 +408,11 @@ export default class GameScene extends Scene {
 			new TankSprite(this, this.localGameData!.tanks[1])
 		];
 		//Bubble init
-    	this.speechBubbles = [
-    	    new SpeechBubble(this),
-    	    new SpeechBubble(this)
-    	];
-    	// chat init
-    	this.chatInput?.destroy();
+		this.speechBubbles = [new SpeechBubble(this), new SpeechBubble(this)];
+		// chat init
+		this.chatInput?.destroy();
 		this.chatInput = new ChatInput(this, (text) => {
-    		this.room!.send('chat', { text });
+			this.room!.send('chat', { text });
 			this.chatInput.block(CHAT_BUBBLE_DURATION);
 		});
 		this.projView = new ProjectileView(this);
@@ -443,7 +440,7 @@ export default class GameScene extends Scene {
 		this.speechBubbles[1].sync(data.tanks[1]);
 		// chat
 		if (Input.Keyboard.JustDown(this.chatKey)) {
-    	this.chatInput?.open();
+			this.chatInput?.open();
 		}
 		// Sync projectile with client-side trail
 		const proj = data.projectile;

--- a/src/lib/game/phaser/scenes/gameScene.ts
+++ b/src/lib/game/phaser/scenes/gameScene.ts
@@ -12,8 +12,8 @@ import type { GameRoomState } from '../../colyseus/schema/GameRoomState';
 import { COLORS, COLOR_STRINGS } from '../colors';
 import { EventBus } from '../EventBus';
 // Chat input and bubble component
-import { SpeechBubble } from '$lib/game/client/view/SpeechBubble';
-import { ChatInput } from '$lib/game/client/view/ChatInput';
+import { SpeechBubble } from '../../client/view/speechBubble';
+import { ChatInput } from '../../client/view/ChatInput';
 import { CHAT_BUBBLE_DURATION } from '$lib/game/shared/chatConfig';
 
 const PLAYER_NAMES = ['Player 1', 'Player 2'];
@@ -137,6 +137,8 @@ export default class GameScene extends Scene {
 
 	shutdown() {
 		EventBus.off('theme-changed', this.onThemeChanged);
+		//Chat cleanup
+		this.chatInput?.destroy();
 	}
 
 	private drawSky() {
@@ -175,6 +177,8 @@ export default class GameScene extends Scene {
 			p2Shoot: kb.addKey(Input.Keyboard.KeyCodes.ENTER),
 			weaponKey: kb.addKey(Input.Keyboard.KeyCodes.Q)
 		};
+		//Chat key
+		this.chatKey = kb.addKey(Input.Keyboard.KeyCodes.T);
 	}
 
 	private setupUI() {
@@ -398,7 +402,18 @@ export default class GameScene extends Scene {
 			new TankSprite(this, this.localGameData!.tanks[0]),
 			new TankSprite(this, this.localGameData!.tanks[1])
 		];
-
+		//Bubble init
+    	this.speechBubbles = [
+    	    new SpeechBubble(this),
+    	    new SpeechBubble(this)
+    	];
+    	// chat init
+    	this.chatInput?.destroy();
+		this.chatInput = new ChatInput(this, (text) => {
+			console.log('[client] envoi chat:', text);
+    		this.room!.send('chat', { text });
+			this.chatInput.block(CHAT_BUBBLE_DURATION);
+		});
 		this.projView = new ProjectileView(this);
 	}
 
@@ -419,7 +434,13 @@ export default class GameScene extends Scene {
 		// Sync tank sprites
 		this.tankSprites[0].sync(data.tanks[0]);
 		this.tankSprites[1].sync(data.tanks[1]);
-
+		// Bubble chat
+		this.speechBubbles[0].sync(data.tanks[0]);
+		this.speechBubbles[1].sync(data.tanks[1]);
+		// chat
+		if (Input.Keyboard.JustDown(this.chatKey)) {
+    	this.chatInput?.open();
+		}
 		// Sync projectile with client-side trail
 		const proj = data.projectile;
 		if (proj.active) {


### PR DESCRIPTION
## What
Implement real-time in-game chat with speech bubbles displayed above tanks during a match.

Closes #80

## How
- Added `SpeechBubble` class (`client/view/speechBubble.ts`) handling rendering, positioning, and auto-dismiss via `CHAT_BUBBLE_DURATION`
- Pressing `t` opens/closes the chat input; focus is managed to avoid conflicts with game controls
- On submit, the message is sent to the Colyseus server via a `"chat"` message, broadcast to all clients in the room
- Each client updates the corresponding tank's speech bubble on receipt
- Timer is reset on each new message; if a bubble is already visible the input is blocked (anti-spam)
- Bubble position is synced to the tank's `x/y` state each frame via `sync(tank)`

## Checklist
- [x] Tests
- [x] Code review