### PR TITLE
docs(adr): add previous undocumented ADRs 001–009

### DIFF
--- a/docs/adr/adr-001-user-sveltekit-as-full-stack-framework.md
+++ b/docs/adr/adr-001-user-sveltekit-as-full-stack-framework.md
@@ -1,0 +1,41 @@
+# ADR-001 — Use SvelteKit as Full-Stack Framework
+
+| Field   | Value      |
+| ------- | ---------- |
+| Date    | 2026-04-27 |
+| Status  | Accepted   |
+| Authors | @42Timeo   |
+
+## Context
+
+The project was initialized with SvelteKit in commit `8032c9b`, which explicitly states “initialize the sveltekit project.”
+The current repository structure still reflects that choice through `src/routes`, `src/lib`, `svelte.config.js`, and `vite.config.ts`.
+
+## Decision
+
+We decided to use SvelteKit as the full-stack framework for the application.
+
+## Options Considered
+
+- **SvelteKit (chosen)** — unified frontend and server routing, good TypeScript integration, easy SSR and form handling.
+- Separate frontend and backend apps — clearer separation, but more setup and more coordination overhead.
+- Plain Vite SPA — simpler frontend setup, but less built-in server and routing support.
+
+## Consequences
+
+**Positive**
+
+- One codebase could host UI, routes, server hooks, and shared libraries.
+- The team could move quickly with conventions already provided by the framework.
+
+**Accepted compromises**
+
+- Framework conventions shaped file layout and routing patterns.
+- Some server concerns still needed custom handling outside default SvelteKit patterns.
+
+## Links
+
+| Type   | Reference                                                     |
+| ------ | ------------------------------------------------------------- |
+| Commit | `8032c9b chore(core): initialize the sveltekit project`       |
+| Docs   | `src/routes`, `src/lib`, `svelte.config.js`, `vite.config.ts` |

--- a/docs/adr/adr-002-user-phaser-4-for-the-browser-game.md
+++ b/docs/adr/adr-002-user-phaser-4-for-the-browser-game.md
@@ -1,0 +1,41 @@
+# ADR-002 — Use Phaser 4 for the Browser Game
+
+| Field   | Value               |
+| ------- | ------------------- |
+| Date    | 2026-04-28          |
+| Status  | Accepted            |
+| Authors | @amidigov, @42Timeo |
+
+## Context
+
+Commit `d64d824` introduced “game using phaser4 inside sveltekit” and describes adding Phaser with a working local game.
+The current tree still contains a dedicated Phaser layer under `src/lib/game/phaser/` with scenes, objects, and game bootstrap files.
+
+## Decision
+
+We decided to use Phaser 4 as the in-browser rendering and gameplay engine.
+
+## Options Considered
+
+- **Phaser 4 (chosen)** — mature game-loop model, scene system, browser-focused tooling.
+- Custom Canvas/WebGL engine — more control, but much more low-level work.
+- DOM-based game UI — easier for menus, but weak for real-time gameplay.
+
+## Consequences
+
+**Positive**
+
+- The team gained a clear scene-based structure for client gameplay.
+- Rendering concerns stayed separate from route and UI concerns.
+
+**Accepted compromises**
+
+- Game code followed engine-specific patterns.
+- Integrating Phaser state with app state required extra coordination.
+
+## Links
+
+| Type   | Reference                                                           |
+| ------ | ------------------------------------------------------------------- |
+| Commit | `d64d824 feat(game): implement game using phaser4 inside sveltekit` |
+| Docs   | `src/lib/game/phaser/`                                              |

--- a/docs/adr/adr-003-user-prisma-as-the-orm.md
+++ b/docs/adr/adr-003-user-prisma-as-the-orm.md
@@ -1,0 +1,41 @@
+# ADR-003 — Use Prisma as the ORM
+
+| Field   | Value                         |
+| ------- | ----------------------------- |
+| Date    | 2026-05-06                    |
+| Status  | Accepted                      |
+| Authors | @42Timeo, @ketodin, @jaubry-- |
+
+## Context
+
+Commit `c06db73` added Prisma ORM, database connection logic, Prisma schema handling, and database scripts.
+The repository currently includes `prisma/schema.prisma`, Prisma commands in `package.json`, and a dedicated `src/lib/server/db.ts` location for database access.
+
+## Decision
+
+We decided to use Prisma as the ORM and schema management layer for persistence.
+
+## Options Considered
+
+- **Prisma (chosen)** — typed client, schema-driven workflow, strong tooling.
+- Raw SQL — maximum control, but more boilerplate and less consistency.
+- Lighter query builders — simpler runtime surface, but fewer integrated workflows.
+
+## Consequences
+
+**Positive**
+
+- Schema, client generation, and DB commands became standardized.
+- Form and auth features could build on one shared data access layer.
+
+**Accepted compromises**
+
+- Code generation became part of the workflow.
+- Prisma-specific runtime and deployment concerns had to be handled explicitly.
+
+## Links
+
+| Type   | Reference                                                      |
+| ------ | -------------------------------------------------------------- |
+| Commit | `c06db73 feat(db): add prisma orm`                             |
+| Docs   | `prisma/schema.prisma`, `db:push`, `db:generate`, `db:migrate` |

--- a/docs/adr/adr-004-use-sqlite-with-better-sqlite3-for-the-initial-databse.md
+++ b/docs/adr/adr-004-use-sqlite-with-better-sqlite3-for-the-initial-databse.md
@@ -1,0 +1,41 @@
+# ADR-004 — Use SQLite with better-sqlite3 for the Initial Database
+
+| Field   | Value      |
+| ------- | ---------- |
+| Date    | 2026-05-07 |
+| Status  | Accepted   |
+| Authors | @42Timeo   |
+
+## Context
+
+Commit `1b9ccdb` made Prisma work in production by moving `prismaadapter-better-sqlite3` to runtime dependencies.
+The current repository contains `data/database.db`, and `package.json` includes `@prisma/adapter-better-sqlite3` plus `@types/better-sqlite3`.
+
+## Decision
+
+We decided to use SQLite, via `better-sqlite3` and the Prisma adapter, as the initial project database.
+
+## Options Considered
+
+- **SQLite + better-sqlite3 (chosen)** — simple setup, local-first workflow, low ops cost.
+- PostgreSQL — stronger multi-user scaling, but heavier setup for the early stage.
+- In-memory or file-only custom persistence — quick to start, but weak long-term structure.
+
+## Consequences
+
+**Positive**
+
+- Local development stayed simple and fast.
+- Deployments could start without provisioning a separate DB service.
+
+**Accepted compromises**
+
+- A later migration to PostgreSQL may still be needed.
+- Concurrency and operational scaling are more limited than with a server DB.
+
+## Links
+
+| Type   | Reference                                            |
+| ------ | ---------------------------------------------------- |
+| Commit | `1b9ccdb fix(chore): make prisma work in production` |
+| Docs   | `data/database.db`, `@prisma/adapter-better-sqlite3` |

--- a/docs/adr/adr-005-use-paraglidejs-for-internationalization.md
+++ b/docs/adr/adr-005-use-paraglidejs-for-internationalization.md
@@ -1,0 +1,41 @@
+# ADR-005 — Use ParaglideJS for Internationalization
+
+| Field   | Value                       |
+| ------- | --------------------------- |
+| Date    | 2026-05-11                  |
+| Status  | Accepted                    |
+| Authors | @PabloBellissant, @pabellis |
+
+## Context
+
+Commit `cdcd7f8` added language support, and earlier initialization notes already mentioned including Paraglide in the project setup.
+The current codebase contains `messages/en.json`, `messages/es.json`, `messages/fr.json`, and a `generate` script that runs `paraglide-js compile`.
+
+## Decision
+
+We decided to use ParaglideJS for internationalization and message compilation.
+
+## Options Considered
+
+- **ParaglideJS (chosen)** — typed messages, compile step, Svelte-friendly workflow.
+- Hand-rolled JSON lookup system — simpler at first, but weaker tooling.
+- Another i18n framework — possible, but would have required different conventions.
+
+## Consequences
+
+**Positive**
+
+- Language files became explicit project assets.
+- Translation support could be wired into routing and UI early.
+
+**Accepted compromises**
+
+- Message compilation became part of generate/typecheck workflows.
+- Generated i18n output had to be excluded from some lint/format steps.
+
+## Links
+
+| Type   | Reference                                           |
+| ------ | --------------------------------------------------- |
+| Commit | `cdcd7f8 feat(front): add language support`         |
+| Docs   | `messages/*.json`, `pnpm exec paraglide-js compile` |

--- a/docs/adr/adr-006-use-colyseus-for-real-time-multiplayer.md
+++ b/docs/adr/adr-006-use-colyseus-for-real-time-multiplayer.md
@@ -1,0 +1,41 @@
+# ADR-006 — Use Colyseus for Real-Time Multiplayer
+
+| Field   | Value                          |
+| ------- | ------------------------------ |
+| Date    | 2026-05-13                     |
+| Status  | Accepted                       |
+| Authors | @amidigov, @42Timeo, @jaubry-- |
+
+## Context
+
+Commit `8e328b2` plugged Colyseus into the project and describes the first implementation of Colyseus, later making it work while restructuring server code and build setup.
+The current repository contains `server/index.cts`, `server/rooms/TankRoom.cts`, `@colyseus/sdk`, `colyseus`, and Colyseus schema files under `src/lib/game/colyseus/schema/`.
+
+## Decision
+
+We decided to use Colyseus as the real-time multiplayer server layer.
+
+## Options Considered
+
+- **Colyseus (chosen)** — room model, state sync, game-oriented abstractions.
+- Custom WebSocket server — more control, but more networking work.
+- Polling or REST-only updates — simpler backend, but poor fit for real-time play.
+
+## Consequences
+
+**Positive**
+
+- The project gained a dedicated room/server model for multiplayer state.
+- State synchronization concerns were separated from browser rendering code.
+
+**Accepted compromises**
+
+- Server runtime and build configuration became more complex.
+- Multiplayer code had to align with Colyseus schemas and lifecycle patterns.
+
+## Links
+
+| Type   | Reference                                                                        |
+| ------ | -------------------------------------------------------------------------------- |
+| Commit | `8e328b2 task(game): plug colysseus`                                             |
+| Docs   | `server/index.cts`, `server/rooms/TankRoom.cts`, `src/lib/game/colyseus/schema/` |

--- a/docs/adr/adr-007-use-better-auth-for-authentication.md
+++ b/docs/adr/adr-007-use-better-auth-for-authentication.md
@@ -1,0 +1,41 @@
+# ADR-007 — Use Better-Auth for Authentication
+
+| Field   | Value                                              |
+| ------- | -------------------------------------------------- |
+| Date    | 2026-05-13                                         |
+| Status  | Accepted                                           |
+| Authors | @Rev0li, @okientzl, @pabellis, @42Timeo, @jaubry-- |
+
+## Context
+
+Commit `1660e56` added Better-Auth dependencies, auth server files, middleware, login/register routes, and schema changes.
+The current project includes `src/lib/server/auth.ts`, `src/lib/auth-client.ts`, `hooks.server.ts`, and Better-Auth dependencies in `package.json`.
+
+## Decision
+
+We decided to use Better-Auth for authentication across browser and server flows.
+
+## Options Considered
+
+- **Better-Auth (chosen)** — integrated auth flows, adapter support, browser/server split.
+- Custom auth implementation — flexible, but more security risk and more maintenance.
+- Another auth library — possible, but not the path reflected in the codebase.
+
+## Consequences
+
+**Positive**
+
+- Auth concerns gained a dedicated server module and client helper.
+- Login and register routes could be implemented quickly on top of the chosen stack.
+
+**Accepted compromises**
+
+- Runtime initialization and env handling required care, especially for deployment.
+- Database schema and auth flow were now coupled to the auth library.
+
+## Links
+
+| Type   | Reference                                                             |
+| ------ | --------------------------------------------------------------------- |
+| Commit | `1660e56 feat(auth): add basics of authentication`                    |
+| Docs   | `src/lib/server/auth.ts`, `src/lib/auth-client.ts`, `hooks.server.ts` |

--- a/docs/adr/adr-008-use-shared-lib-game-modules-across-client-and-server.md
+++ b/docs/adr/adr-008-use-shared-lib-game-modules-across-client-and-server.md
@@ -1,0 +1,41 @@
+# ADR-008 — Use Shared `lib/game` Modules Across Client and Server
+
+| Field   | Value                          |
+| ------- | ------------------------------ |
+| Date    | 2026-05-13                     |
+| Status  | Accepted                       |
+| Authors | @amidigov, @42Timeo, @jaubry-- |
+
+## Context
+
+The Colyseus integration commit includes a structural cleanup that renamed server-related areas and kept shared game logic as a distinct concern.
+The current tree shows a deliberate split between `src/lib/game/client`, `src/lib/game/phaser`, `src/lib/game/colyseus`, `src/lib/game/shared`, and `server/rooms`.
+
+## Decision
+
+We decided to keep game domain code in shared modules under `src/lib/game`, with separate layers for client rendering, Colyseus schemas, and reusable shared state/logic.
+
+## Options Considered
+
+- **Shared `lib/game` split (chosen)** — reuse rules and state definitions across layers.
+- Duplicate logic in client and server — simpler boundaries, but high drift risk.
+- Keep all game code server-only — authoritative, but harder to prototype rich local behavior.
+
+## Consequences
+
+**Positive**
+
+- Core game concepts such as state, terrain, and physics could live in one place.
+- The codebase gained clearer boundaries between rendering, networking, and reusable logic.
+
+**Accepted compromises**
+
+- Shared modules had to stay runtime-compatible across multiple environments.
+- Layer boundaries required discipline to avoid accidental coupling.
+
+## Links
+
+| Type   | Reference                                                       |
+| ------ | --------------------------------------------------------------- |
+| Commit | `8e328b2 task(game): plug colysseus`                            |
+| Docs   | `src/lib/game/{client,colyseus,phaser,shared}`, `server/rooms/` |

--- a/docs/adr/adr-009-use-docker-and-compose-for-deployment.md
+++ b/docs/adr/adr-009-use-docker-and-compose-for-deployment.md
@@ -1,0 +1,41 @@
+# ADR-009 — Use Docker and Compose for Deployment
+
+| Field   | Value      |
+| ------- | ---------- |
+| Date    | 2026-05-17 |
+| Status  | Accepted   |
+| Authors | @ketodin   |
+
+## Context
+
+Commit `94b99fe` added a Dockerfile, entrypoint, Compose file, env example updates, and deployment-related auth fixes.
+The current tree contains `Dockerfile`, `compose.yaml`, and `entrypoint.sh`.
+
+## Decision
+
+We decided to package and run the application with Docker and Docker Compose.
+
+## Options Considered
+
+- **Docker + Compose (chosen)** — reproducible local and deployment setup.
+- Host-native deployment — less container overhead, but more machine drift.
+- Separate per-service manual scripts — possible, but harder to standardize.
+
+## Consequences
+
+**Positive**
+
+- The application gained a clearer deployment path.
+- Runtime setup for app, env, and startup steps became explicit artifacts in the repo.
+
+**Accepted compromises**
+
+- Container startup and dependency packaging added operational complexity.
+- Auth and database runtime behavior had to be validated inside the containerized environment.
+
+## Links
+
+| Type   | Reference                                     |
+| ------ | --------------------------------------------- |
+| Commit | `94b99fe chore(infra): add docker compose`    |
+| Docs   | `Dockerfile`, `compose.yaml`, `entrypoint.sh` |


### PR DESCRIPTION
## What

Retroactively documents all major architectural decisions made since project start, using Git history and current codebase as source material.

Closes #70 

## How

Each ADR was reconstructed by cross-referencing:
- `git log main --oneline --no-merges` for commit anchors and chronological ordering
- `package.json` to confirm library choices and versions
- `tree.txt` to confirm current structural decisions still in effect

ADRs are ordered chronologically by the first commit that introduced each decision. The seeded PRNG candidate was intentionally excluded — no commit in the history clearly evidences the decision.

Files added under `docs/adr/`:
- `ADR-001-use-sveltekit-as-full-stack-framework.md`
- `ADR-002-use-phaser-4-for-the-browser-game.md`
- `ADR-003-use-prisma-as-the-orm.md`
- `ADR-004-use-sqlite-with-better-sqlite3-for-the-initial-database.md`
- `ADR-005-use-paraglidejs-for-internationalization.md`
- `ADR-006-use-colyseus-for-real-time-multiplayer.md`
- `ADR-007-use-better-auth-for-authentication.md`
- `ADR-008-use-shared-lib-game-modules-across-client-and-server.md`
- `ADR-009-use-docker-and-compose-for-deployment.md`
- `docs/adr/.gitkeep` removed

Reviewer attention: the "Options Considered" sections are educated reconstructions — if you remember a concrete option that was actually debated, please add it before merging.

## Checklist

- [ ] Documentation updated if needed