### PR TITLE
fix(front): Fix shader theme crash some browser

### DIFF
--- a/src/lib/shader-theme.ts
+++ b/src/lib/shader-theme.ts
@@ -1,12 +1,10 @@
+import { browser } from '$app/environment';
 import { writable } from 'svelte/store';
 
 export type ShaderTheme = 'dark' | 'light';
 
 function createShaderTheme() {
-	const stored =
-		typeof localStorage !== 'undefined'
-			? (localStorage.getItem('shaderTheme') as ShaderTheme | null)
-			: null;
+	const stored = browser ? (localStorage.getItem('shaderTheme') as ShaderTheme | null) : null;
 
 	const initial: ShaderTheme = stored ?? 'dark';
 
@@ -15,9 +13,10 @@ function createShaderTheme() {
 	return {
 		subscribe,
 		set: (value: ShaderTheme) => {
-			if (typeof localStorage !== 'undefined') {
+			if (browser) {
 				localStorage.setItem('shaderTheme', value);
 			}
+
 			set(value);
 		},
 		update
@@ -30,7 +29,7 @@ export function toggleShaderTheme() {
 	shaderTheme.update((t) => {
 		const next = t === 'dark' ? 'light' : 'dark';
 
-		if (typeof localStorage !== 'undefined') {
+		if (browser) {
 			localStorage.setItem('shaderTheme', next);
 		}
 


### PR DESCRIPTION
## What

Fixed the shader crash.

Closes #110 

## How

Replaced the line
- typeof localStorage !== 'undefined'
by
-  browser


## Checklist

- [ ] Work again.
