### PR TITLE
chore(db): add a database seeding script

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -32,7 +32,7 @@ export default defineConfig(
 			globals: { ...globals.browser, ...globals.node },
 			parserOptions: {
 				projectService: {
-					allowDefaultProject: ['*.config.js', '*.config.ts', 'index.ts'],
+					allowDefaultProject: ['*.config.js', '*.config.ts', 'index.ts', 'scripts/*.ts'],
 					defaultProject: 'tsconfig.json'
 				},
 				tsconfigRootDir: import.meta.dirname

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"better-auth": "^1.6.11",
 		"bits-ui": "^2.18.0",
 		"clsx": "^2.1.1",
+		"dotenv": "^17.4.2",
 		"eslint": "^10.2.0",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-svelte": "^3.17.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
       eslint:
         specifier: ^10.2.0
         version: 10.4.0(jiti@2.7.0)

--- a/scripts/db-seed.ts
+++ b/scripts/db-seed.ts
@@ -5,15 +5,26 @@ import { twoFactor } from 'better-auth/plugins';
 import { betterAuth } from 'better-auth';
 import 'dotenv/config';
 
-const DEFAULT_PASSWORD = 'abcdef12';
-
-const users: {
+type User = {
 	key: string;
 	email: string;
 	name: string;
 	password?: string;
-}[] = [
+};
+
+type Friendship = {
+	sender: string;
+	receiver: string;
+	status: 'ACCEPTED' | 'PENDING';
+};
+
+const DEFAULT_PASSWORD = 'abcdef12';
+
+const users: User[] = [
 	{ key: 'abc', email: 'abc@def.com', name: 'abc' },
+	{ key: 'aaa', email: 'aaa@gmail.com', name: 'aaa', password: '00000000' },
+	{ key: 'bbb', email: 'bbb@gmail.com', name: 'bbb', password: '00000000' },
+	{ key: 'ccc', email: 'ccc@gmail.com', name: 'ccc', password: '00000000' },
 	{ key: 'test', email: 'test@test.test', name: 'Test' },
 	{ key: 'emporio', email: 'emporio@gmail.com', name: 'Emporio' },
 	{ key: 'daclino', email: 'timeo@daclino.fr', name: 'TimeoDaclino' },
@@ -31,24 +42,26 @@ const users: {
 	}
 ];
 
-const friendships: {
-	sender: string;
-	receiver: string;
-	status: 'ACCEPTED' | 'PENDING';
-}[] = [
-	{ sender: 'daclino', receiver: 'abc', status: 'ACCEPTED' },
-	{ sender: 'emporio', receiver: 'abc', status: 'ACCEPTED' },
-	{ sender: 'abc', receiver: 'ketodin', status: 'ACCEPTED' },
-	{ sender: 'adrilava', receiver: 'abc', status: 'PENDING' },
-	{ sender: 'ledon', receiver: 'abc', status: 'PENDING' },
-	{ sender: 'abc', receiver: 'revoli', status: 'PENDING' },
-	{ sender: 'daclino', receiver: 'test', status: 'ACCEPTED' },
-	{ sender: 'emporio', receiver: 'test', status: 'ACCEPTED' },
-	{ sender: 'test', receiver: 'ketodin', status: 'ACCEPTED' },
-	{ sender: 'adrilava', receiver: 'test', status: 'PENDING' },
-	{ sender: 'ledon', receiver: 'test', status: 'PENDING' },
-	{ sender: 'test', receiver: 'revoli', status: 'PENDING' }
+const friendships: Friendship[] = [
+	...defaultFriends('abc'),
+	...defaultFriends('test'),
+	...defaultFriends('aaa'),
+	...defaultFriends('bbb'),
+	...defaultFriends('ccc')
 ];
+
+function defaultFriends(user: string): Friendship[] {
+	return [
+		{ sender: 'daclino', receiver: user, status: 'ACCEPTED' },
+		{ sender: 'emporio', receiver: user, status: 'ACCEPTED' },
+		{ sender: user, receiver: 'ketodin', status: 'ACCEPTED' },
+		{ sender: 'lespenel', receiver: user, status: 'PENDING' },
+		{ sender: 'adrilava', receiver: user, status: 'PENDING' },
+		{ sender: 'charly', receiver: user, status: 'PENDING' },
+		{ sender: 'ledon', receiver: user, status: 'PENDING' },
+		{ sender: user, receiver: 'revoli', status: 'PENDING' }
+	];
+}
 
 const url = process.env.DATABASE_URL ?? 'file:./dev.db';
 const adapter = new PrismaBetterSqlite3({ url });

--- a/scripts/db-seed.ts
+++ b/scripts/db-seed.ts
@@ -7,7 +7,7 @@ import 'dotenv/config';
 
 const DEFAULT_PASSWORD = 'abcdef12';
 
-let users: {
+const users: {
 	key: string;
 	email: string;
 	name: string;
@@ -108,13 +108,13 @@ async function ensureFriendship(
 }
 
 async function main() {
-	let userIds: Map<string, string> = new Map<string, string>();
+	const userIds = new Map<string, string>();
 
-	for (let user of users) {
+	for (const user of users) {
 		userIds.set(user.key, await ensureUser(user));
 	}
 
-	for (let friendship of friendships) {
+	for (const friendship of friendships) {
 		await ensureFriendship(userIds, friendship);
 	}
 }

--- a/scripts/db-seed.ts
+++ b/scripts/db-seed.ts
@@ -1,0 +1,129 @@
+import { PrismaBetterSqlite3 } from '@prisma/adapter-better-sqlite3';
+import { PrismaClient } from '../src/lib/server/prisma/client';
+import { prismaAdapter } from 'better-auth/adapters/prisma';
+import { twoFactor } from 'better-auth/plugins';
+import { betterAuth } from 'better-auth';
+import 'dotenv/config';
+
+const DEFAULT_PASSWORD = 'abcdef12';
+
+let users: {
+	key: string;
+	email: string;
+	name: string;
+	password?: string;
+}[] = [
+	{ key: 'abc', email: 'abc@def.com', name: 'abc' },
+	{ key: 'test', email: 'test@test.test', name: 'Test' },
+	{ key: 'emporio', email: 'emporio@gmail.com', name: 'Emporio' },
+	{ key: 'daclino', email: 'timeo@daclino.fr', name: 'TimeoDaclino' },
+	{ key: 'ketodin', email: 'ketodin@mail.com', name: 'Ketodin' },
+	{ key: 'revoli', email: 'revoli@mail.com', name: 'Revoli' },
+	{ key: 'ledon', email: 'le.don@mail.com', name: 'le Don' },
+	{ key: 'charly', email: 'charly@mail.com', name: 'charly' },
+	{ key: 'lespenel', email: 'lespenel@mail.com', name: 'lespenel' },
+	{ key: 'androux', email: 'androux@mail.com', name: 'Androux' },
+	{
+		key: 'adrilava',
+		email: 'adrilavaa@gmail.com',
+		name: 'AdrilavaMinecraft',
+		password: 'otherpassword'
+	}
+];
+
+const friendships: {
+	sender: string;
+	receiver: string;
+	status: 'ACCEPTED' | 'PENDING';
+}[] = [
+	{ sender: 'daclino', receiver: 'abc', status: 'ACCEPTED' },
+	{ sender: 'emporio', receiver: 'abc', status: 'ACCEPTED' },
+	{ sender: 'abc', receiver: 'ketodin', status: 'ACCEPTED' },
+	{ sender: 'adrilava', receiver: 'abc', status: 'PENDING' },
+	{ sender: 'ledon', receiver: 'abc', status: 'PENDING' },
+	{ sender: 'abc', receiver: 'revoli', status: 'PENDING' },
+	{ sender: 'daclino', receiver: 'test', status: 'ACCEPTED' },
+	{ sender: 'emporio', receiver: 'test', status: 'ACCEPTED' },
+	{ sender: 'test', receiver: 'ketodin', status: 'ACCEPTED' },
+	{ sender: 'adrilava', receiver: 'test', status: 'PENDING' },
+	{ sender: 'ledon', receiver: 'test', status: 'PENDING' },
+	{ sender: 'test', receiver: 'revoli', status: 'PENDING' }
+];
+
+const url = process.env.DATABASE_URL ?? 'file:./dev.db';
+const adapter = new PrismaBetterSqlite3({ url });
+const prisma = new PrismaClient({ adapter });
+
+export const auth = betterAuth({
+	database: prismaAdapter(prisma, {
+		provider: 'sqlite'
+	}),
+	experimental: { joins: true },
+	emailAndPassword: { enabled: true },
+	plugins: [
+		twoFactor({
+			issuer: 'ft_transcendence',
+			TOTPOptions: { window: 1 },
+			backupCodes: { count: 8, length: 10 }
+		})
+	]
+});
+
+async function ensureUser(user: (typeof users)[number]) {
+	const existing = await prisma.user.findUnique({
+		where: { email: user.email }
+	});
+	if (existing) {
+		return existing.id;
+	}
+
+	const result = await auth.api.signUpEmail({
+		body: {
+			email: user.email,
+			name: user.name,
+			password: user.password ?? DEFAULT_PASSWORD
+		}
+	});
+	return result.user.id;
+}
+
+async function ensureFriendship(
+	userIds: Map<string, string>,
+	friendship: (typeof friendships)[number]
+) {
+	await prisma.friendRequest.upsert({
+		where: {
+			senderId_receiverId: {
+				senderId: userIds.get(friendship.sender)!,
+				receiverId: userIds.get(friendship.receiver)!
+			}
+		},
+		update: { status: friendship.status },
+		create: {
+			senderId: userIds.get(friendship.sender)!,
+			receiverId: userIds.get(friendship.receiver)!,
+			status: friendship.status
+		}
+	});
+}
+
+async function main() {
+	let userIds: Map<string, string> = new Map<string, string>();
+
+	for (let user of users) {
+		userIds.set(user.key, await ensureUser(user));
+	}
+
+	for (let friendship of friendships) {
+		await ensureFriendship(userIds, friendship);
+	}
+}
+
+main()
+	.catch((error) => {
+		console.error(error);
+		process.exit(1);
+	})
+	.finally(async () => {
+		await prisma.$disconnect();
+	});

--- a/scripts/db-seed.ts
+++ b/scripts/db-seed.ts
@@ -21,7 +21,7 @@ type Friendship = {
 const DEFAULT_PASSWORD = 'abcdef12';
 
 const users: User[] = [
-	{ key: 'abc', email: 'abc@def.com', name: 'abc' },
+	{ key: 'abc', email: 'abc@gmail.com', name: 'abc' },
 	{ key: 'aaa', email: 'aaa@gmail.com', name: 'aaa', password: '00000000' },
 	{ key: 'bbb', email: 'bbb@gmail.com', name: 'bbb', password: '00000000' },
 	{ key: 'ccc', email: 'ccc@gmail.com', name: 'ccc', password: '00000000' },


### PR DESCRIPTION
## What

Add a script in *scripts/db-seed.ts* which fill the database with test users and friends.
**Don't hesitate to add your test users.**

Closes #135

## How
To run it, `pnpm exec tsx scripts/db-seed.ts`.

An example test user is: *test@test.test* with password *abcdef12*

I needed to add dotenv to load the BETTER_AUTH_SECRET from .env which need to be the same for the script and run.

## Checklist

- [ ] Check that it works
- [ ] Add your tests users
