### PR TITLE
fix(game): Fuel and projectiles info are now hidden for oponent

### DIFF
--- a/src/lib/game/phaser/scenes/gameScene.ts
+++ b/src/lib/game/phaser/scenes/gameScene.ts
@@ -745,10 +745,10 @@ export default class GameScene extends Scene {
 			this.turnText.setText(`${PLAYER_NAMES[currentPlayer]}'s Turn`);
 		}
 
-		this.updateFuelBar(data.fuel);
-		this.updateHealthBar(data.tanks[this.myPlayerIndex].health);
 		const isMyTurn = currentPlayer === this.myPlayerIndex && phase === 'AIMING';
-		this.updateWeaponUI(data.weaponIndex, isMyTurn);
+		if (isMyTurn) this.updateFuelBar(data.fuel);
+		this.updateHealthBar(data.tanks[this.myPlayerIndex].health);
+		this.updateWeaponUI(isMyTurn ? data.weaponIndex : -1, isMyTurn);
 		this.drawFireButton(this.fireBtnHovered && isMyTurn, !isMyTurn);
 		this.drawMoveButton(0, this.moveLeftBtnHovered && isMyTurn, !isMyTurn);
 		this.drawMoveButton(1, this.moveRightBtnHovered && isMyTurn, !isMyTurn);


### PR DESCRIPTION
## What

Fuel bar and projectile selection is now hidden for oponent player.

Closes #150 

## How

Added an "ismyturn" condition for fuel and projectiles screen update in gameScene.ts

## Checklist

- [ ] No unintended side effects
