### PR TITLE
feat(game): SSR is now implemented for the game

### DIFF
--- a/src/lib/components/GameWindow.svelte
+++ b/src/lib/components/GameWindow.svelte
@@ -9,8 +9,6 @@
 
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import StartGame from '$lib/game/phaser/game';
-	import { EventBus } from '$lib/game/phaser/EventBus';
 	import { syncFromCSS } from '$lib/game/phaser/colors';
 
 	let {
@@ -21,23 +19,30 @@
 	} = $props();
 
 	onMount(() => {
-		syncFromCSS();
-		phaserRef.game = StartGame('game-container');
+		let observer: MutationObserver | undefined;
 
-		const observer = new MutationObserver(() => {
+		void (async () => {
+			const { default: StartGame } = await import('$lib/game/phaser/game');
+			const { EventBus } = await import('$lib/game/phaser/EventBus');
+
 			syncFromCSS();
-			EventBus.emit('theme-changed');
-		});
-		observer.observe(document.documentElement, { attributeFilter: ['class'] });
+			phaserRef.game = StartGame('game-container');
 
-		EventBus.on('current-scene-ready', (scene_instance: unknown) => {
-			phaserRef.scene = scene_instance as Scene;
-			// if (currentActiveScene) {
-			//     currentActiveScene(scene_instance);
-			// }
-		});
+			observer = new MutationObserver(() => {
+				syncFromCSS();
+				EventBus.emit('theme-changed');
+			});
+			observer.observe(document.documentElement, { attributeFilter: ['class'] });
 
-		return () => observer.disconnect();
+			EventBus.on('current-scene-ready', (scene_instance: unknown) => {
+				phaserRef.scene = scene_instance as Scene;
+				// if (currentActiveScene) {
+				//     currentActiveScene(scene_instance);
+				// }
+			});
+		})();
+
+		return () => observer?.disconnect();
 	});
 </script>
 

--- a/src/routes/game/+page.ts
+++ b/src/routes/game/+page.ts
@@ -1,1 +1,0 @@
-export const ssr = false;


### PR DESCRIPTION
## What

SSR is now enabled for the game.

Closes #140 

## How

- Deleted +page.ts file that had export const ssr = false which explicitly disabled SSR.
   Deleting it lets the route use SvelteKit's default, which is SSR enabled.

- Moved Phaser imports inside onMount
Before:

import StartGame from '$lib/game/phaser/game';
import { EventBus } from '$lib/game/phaser/EventBus';

After:

const { default: StartGame } = await import('$lib/game/phaser/game');
const { EventBus } = await import('$lib/game/phaser/EventBus');

By moving them to dynamic imports inside onMount, they only execute in the browser. onMount never runs on the server, that's a Svelte guarantee.


## Checklist

- [ ] No unintended side effects
