### PR TITLE
fix(front): refresh language

### DIFF
--- a/src/lib/components/LanguagePicker.svelte
+++ b/src/lib/components/LanguagePicker.svelte
@@ -1,20 +1,19 @@
 <script lang="ts">
-	import { getLocale, setLocale } from '$lib/paraglide/runtime';
+	import { getLocale } from '$lib/paraglide/runtime';
+	import { setLocale, type Locale } from '$lib/locale.svelte';
 
-	const languages = [
+	const languages: { code: Locale; flag: string }[] = [
 		{ code: 'fr', flag: '🇫🇷' },
 		{ code: 'en', flag: '🇬🇧' },
 		{ code: 'es', flag: '🇪🇸' }
-	] as const;
+	];
 
-	type Locale = (typeof languages)[number]['code'];
-
-	let current = $state(getLocale() satisfies Locale);
+	let current = $state(getLocale() as Locale);
 	let open = $state(false);
 
 	function selectLanguage(code: Locale) {
 		current = code;
-		void setLocale(current);
+		setLocale(code);
 		open = false;
 	}
 

--- a/src/lib/components/LanguagePicker.svelte
+++ b/src/lib/components/LanguagePicker.svelte
@@ -8,7 +8,7 @@
 		{ code: 'es', flag: '🇪🇸' }
 	];
 
-	let current = $state(getLocale() as Locale);
+	let current = $state(getLocale());
 	let open = $state(false);
 
 	function selectLanguage(code: Locale) {

--- a/src/lib/locale.svelte.ts
+++ b/src/lib/locale.svelte.ts
@@ -1,0 +1,20 @@
+import { browser } from '$app/environment';
+import {
+	getLocale as _getLocale,
+	setLocale as _setLocale,
+	overwriteGetLocale,
+	locales
+} from '$lib/paraglide/runtime';
+
+export type Locale = (typeof locales)[number];
+
+let _locale = $state<Locale>(_getLocale());
+
+if (browser) {
+	overwriteGetLocale(() => _locale);
+}
+
+export function setLocale(locale: Locale) {
+	void _setLocale(locale, { reload: false });
+	_locale = locale;
+}

--- a/src/lib/locale.svelte.ts
+++ b/src/lib/locale.svelte.ts
@@ -10,11 +10,25 @@ export type Locale = (typeof locales)[number];
 
 let _locale = $state<Locale>(_getLocale());
 
+export function getReactiveLocale(): Locale {
+	return _locale;
+}
+
 if (browser) {
 	overwriteGetLocale(() => _locale);
 }
 
-export function setLocale(locale: Locale) {
-	void _setLocale(locale, { reload: false });
-	_locale = locale;
+import { z } from 'zod';
+import { en, fr, es } from 'zod/locales';
+
+const localeMap = {
+	en,
+	fr,
+	es
+};
+
+export function setLocale(newLocale: Locale) {
+	void _setLocale(newLocale, { reload: false });
+	_locale = newLocale;
+	z.config(localeMap[newLocale]());
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -11,6 +11,7 @@
 	import type { Snippet } from 'svelte';
 	import { shaderTheme } from '$lib/shader-theme';
 	import { useSession } from '$lib/auth-client';
+	import { getReactiveLocale } from '$lib/locale.svelte';
 
 	let { children }: { children: Snippet } = $props();
 
@@ -32,18 +33,20 @@
 
 <Shader base={baseTheme} error={errorTheme} />
 
-{#if !isAuthRoute && $session.data !== null}
-	<div class="app">
-		<Header />
-		<FriendList userId={$session.data.user.id} />
-		<Footer />
+{#key getReactiveLocale()}
+	{#if !isAuthRoute && $session.data !== null}
+		<div class="app">
+			<Header />
+			<FriendList userId={$session.data.user.id} />
+			<Footer />
 
-		<main class="game-container">
-			<div class="content">
-				{@render children?.()}
-			</div>
-		</main>
-	</div>
-{:else}
-	{@render children?.()}
-{/if}
+			<main class="game-container">
+				<div class="content">
+					{@render children?.()}
+				</div>
+			</main>
+		</div>
+	{:else}
+		{@render children?.()}
+	{/if}
+{/key}


### PR DESCRIPTION
## What

Load all text in "local" just change messages not refresh pages

Closes #158 

## How

getReactiveLocale() is a getter function: when Svelte evaluates it in {#key getReactiveLocale()}, it reads _locale in a reactive context and creates the dependency—without violating Svelte 5’s export rule.

