### PR TITLE
refactor(back): better routes protection

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,4 +1,4 @@
-import type { Handle } from '@sveltejs/kit';
+import { type Handle, redirect } from '@sveltejs/kit';
 import { getTextDirection } from '$lib/paraglide/runtime';
 import { paraglideMiddleware } from '$lib/paraglide/server';
 import { auth } from '$lib/server/auth';
@@ -11,6 +11,7 @@ import { TankRoom } from '$lib/game/colyseus/TankRoom';
 import { StatusRoom } from '$lib/game/colyseus/StatusRoom';
 
 let gameServer: ColyseusServer | null = null;
+const PUBLIC_ROUTES = [ '/login', '/register', '/legal/terms', '/legal/privacy', 'favicon.png' ];
 
 const handleParaglide: Handle = ({ event, resolve }) =>
 	paraglideMiddleware(event.request, ({ request, locale }) => {
@@ -44,7 +45,17 @@ export const handleColyseus: Handle = async ({ event, resolve }) => {
 		matchMaker.defineRoomType('tank_room', TankRoom);
 		matchMaker.defineRoomType('status', StatusRoom);
 	}
-	return resolve(event, {});
+	return resolve(event);
 };
 
-export const handle: Handle = sequence(handleParaglide, handleBetterAuth, handleColyseus);
+export const handleRouteProtection: Handle = async ({ event, resolve }) => {
+	const { pathname } = event.url;
+	const isPublic = PUBLIC_ROUTES.some(route => pathname === route);
+	if (!isPublic && !event.locals.user) {
+		const redirectTo = encodeURIComponent(pathname);
+		redirect(303, `/login?redirectTo=${redirectTo}`);
+	}
+	return resolve(event);
+};
+
+export const handle: Handle = sequence(handleColyseus, handleParaglide, handleBetterAuth, handleRouteProtection);

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -11,7 +11,7 @@ import { TankRoom } from '$lib/game/colyseus/TankRoom';
 import { StatusRoom } from '$lib/game/colyseus/StatusRoom';
 
 let gameServer: ColyseusServer | null = null;
-const PUBLIC_ROUTES = [ '/login', '/register', '/legal/terms', '/legal/privacy', 'favicon.png' ];
+const PUBLIC_ROUTES = ['/login', '/register', '/legal/terms', '/legal/privacy', 'favicon.png'];
 
 const handleParaglide: Handle = ({ event, resolve }) =>
 	paraglideMiddleware(event.request, ({ request, locale }) => {
@@ -50,14 +50,18 @@ export const handleColyseus: Handle = async ({ event, resolve }) => {
 
 export const handleRouteProtection: Handle = async ({ event, resolve }) => {
 	const { pathname } = event.url;
-	const isPublic = PUBLIC_ROUTES.some(route => pathname === route);
+	const isPublic = PUBLIC_ROUTES.some((route) => pathname === route);
 	if (!isPublic && !event.locals.user) {
-		if (pathname === '/')
-			return redirect(303, `/login`);
+		if (pathname === '/') return redirect(303, `/login`);
 		const redirectTo = encodeURIComponent(pathname);
 		return redirect(303, `/login?redirectTo=${redirectTo}`);
 	}
 	return resolve(event);
 };
 
-export const handle: Handle = sequence(handleColyseus, handleParaglide, handleBetterAuth, handleRouteProtection);
+export const handle: Handle = sequence(
+	handleColyseus,
+	handleParaglide,
+	handleBetterAuth,
+	handleRouteProtection
+);

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -49,10 +49,11 @@ export const handleColyseus: Handle = async ({ event, resolve }) => {
 };
 
 export const handleRouteProtection: Handle = async ({ event, resolve }) => {
-	const { pathname } = event.url;
+	let { pathname } = event.url;
 	const isPublic = PUBLIC_ROUTES.some((route) => pathname === route);
 	if (!isPublic && !event.locals.user) {
-		if (pathname === '/') return redirect(303, `/login`);
+		if (pathname.startsWith('/')) pathname = pathname.slice(1);
+		if (pathname === '') return redirect(303, `/login`);
 		const redirectTo = encodeURIComponent(pathname);
 		return redirect(303, `/login?redirectTo=${redirectTo}`);
 	}

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -52,8 +52,10 @@ export const handleRouteProtection: Handle = async ({ event, resolve }) => {
 	const { pathname } = event.url;
 	const isPublic = PUBLIC_ROUTES.some(route => pathname === route);
 	if (!isPublic && !event.locals.user) {
+		if (pathname === '/')
+			return redirect(303, `/login`);
 		const redirectTo = encodeURIComponent(pathname);
-		redirect(303, `/login?redirectTo=${redirectTo}`);
+		return redirect(303, `/login?redirectTo=${redirectTo}`);
 	}
 	return resolve(event);
 };

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,9 +1,5 @@
-import { redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = ({ locals }) => {
-	if (!locals.user) {
-		return redirect(303, '/login');
-	}
-	return { user: locals.user };
+	return { user: locals.user! };
 };

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -11,6 +11,7 @@
 	import * as z from 'zod';
 	import { en, fr, es } from 'zod/locales';
 	import google from '$lib/assets/google.png';
+	import { page } from '$app/state';
 
 	const localeMap = { en, fr, es };
 	z.config(localeMap[getLocale()]());
@@ -22,6 +23,9 @@
 	let code = $state('');
 	let useBackup = $state(false);
 	let fieldErrors = $state<{ email?: string; password?: string }>({});
+
+	const redirectTo = page.url.searchParams.get('redirectTo');
+	const redirectUrl = redirectTo ? '/' + decodeURIComponent(redirectTo) : '/';
 
 	async function handleSubmit() {
 		error = '';
@@ -40,7 +44,7 @@
 		await signIn.email({
 			email,
 			password,
-			callbackURL: '/',
+			callbackURL: redirectUrl,
 			fetchOptions: {
 				onSuccess: (ctx) => {
 					if ((ctx.data as Record<string, unknown>)?.twoFactorRedirect) {
@@ -61,7 +65,8 @@
 			error = result.error?.message ?? 'Unknown error';
 			return;
 		}
-		await goto(resolve('/'));
+		// eslint-disable-next-line svelte/no-navigation-without-resolve
+		await goto(redirectUrl, {replaceState: true});
 	}
 
 	async function verifyBackupCode() {
@@ -71,7 +76,8 @@
 			error = result.error?.message ?? 'Unknown error';
 			return;
 		}
-		await goto(resolve('/'));
+		// eslint-disable-next-line svelte/no-navigation-without-resolve
+		await goto(redirectUrl, {replaceState: true});
 	}
 
 	function goBack() {
@@ -81,7 +87,7 @@
 		useBackup = false;
 	}
 	async function signInWithGoogle() {
-		await authClient.signIn.social({ provider: 'google', callbackURL: '/' });
+		await authClient.signIn.social({ provider: 'google', callbackURL: redirectUrl });
 	}
 </script>
 
@@ -153,7 +159,7 @@
 					</button>
 					<p class="text-muted-foreground text-center text-sm">
 						{m.no_account()}
-						<a href={resolve('/register')} class="underline">{m.register()}</a>
+						<a href={resolve(redirectTo ? `/register?redirectTo=${redirectTo}` : '/register')} class="underline">{m.register()}</a>
 					</p>
 				</form>
 			{:else}

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -66,7 +66,7 @@
 			return;
 		}
 		// eslint-disable-next-line svelte/no-navigation-without-resolve
-		await goto(redirectUrl, {replaceState: true});
+		await goto(redirectUrl, { replaceState: true });
 	}
 
 	async function verifyBackupCode() {
@@ -77,7 +77,7 @@
 			return;
 		}
 		// eslint-disable-next-line svelte/no-navigation-without-resolve
-		await goto(redirectUrl, {replaceState: true});
+		await goto(redirectUrl, { replaceState: true });
 	}
 
 	function goBack() {
@@ -159,7 +159,10 @@
 					</button>
 					<p class="text-muted-foreground text-center text-sm">
 						{m.no_account()}
-						<a href={resolve(redirectTo ? `/register?redirectTo=${redirectTo}` : '/register')} class="underline">{m.register()}</a>
+						<a
+							href={resolve(redirectTo ? `/register?redirectTo=${redirectTo}` : '/register')}
+							class="underline">{m.register()}</a
+						>
 					</p>
 				</form>
 			{:else}

--- a/src/routes/profile/[id]/+page.server.ts
+++ b/src/routes/profile/[id]/+page.server.ts
@@ -1,5 +1,5 @@
 import type { PageServerLoad } from './$types';
-import { redirect, error } from '@sveltejs/kit';
+import { error } from '@sveltejs/kit';
 import db from '$lib/server/db';
 import { m } from '$lib/paraglide/messages';
 
@@ -30,16 +30,15 @@ async function isFriend(meId: string, otherId: string): Promise<boolean> {
 }
 
 export const load: PageServerLoad = async ({ locals, params }) => {
-	if (!locals.user) return redirect(303, '/login');
 	const user = await db.user.findUnique({
 		where: { id: params.id }
 	});
 	if (!user) return error(404, m.no_user());
 
 	const userType: UserType =
-		locals.user.id === user.id
+		locals.user!.id === user.id
 			? 'self'
-			: (await isFriend(locals.user.id, user.id))
+			: (await isFriend(locals.user!.id, user.id))
 				? 'friend'
 				: 'someone';
 

--- a/src/routes/register/+page.server.ts
+++ b/src/routes/register/+page.server.ts
@@ -11,7 +11,7 @@ export const load: PageServerLoad = async () => {
 };
 
 export const actions: Actions = {
-	default: async ({ request }) => {
+	default: async ({ request, url }) => {
 		const form = await superValidate(request, zod4(formSchema));
 
 		if (!form.valid) {
@@ -27,6 +27,9 @@ export const actions: Actions = {
 			return setError(form, 'email', m.already_email());
 		}
 
-		return redirect(303, '/');
+		const redirectTo = url.searchParams.get('redirectTo');
+		const redirectUrl = redirectTo ? decodeURIComponent(redirectTo) : '/';
+
+		return redirect(303, '/' + redirectUrl);
 	}
 };

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -12,6 +12,7 @@
 	import { getLocale } from '$lib/paraglide/runtime';
 	import * as z from 'zod';
 	import { en, fr, es } from 'zod/locales';
+	import { page } from '$app/state';
 
 	const localeMap = {
 		en,
@@ -25,6 +26,9 @@
 
 	const form = $derived(superForm(data.form, { validators: zod4Client(formSchema) }));
 	const { form: formData, enhance } = $derived(form);
+
+
+	const redirectTo = page.url.searchParams.get('redirectTo');
 </script>
 
 <div class="bg-muted/30 flex min-h-screen items-center justify-center px-4">
@@ -108,7 +112,8 @@
 					{m.register()}
 				</Form.Button>
 				<p class="text-muted-foreground text-center text-sm">
-					{m.already_account()} <a href={resolve('/login')} class="underline">{m.login()}</a>
+					{m.already_account()}
+					<a href={resolve(redirectTo ? `/login?redirectTo=${redirectTo}` : '/register')} class="underline">{m.login()}</a>
 				</p>
 			</form>
 		</div>

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -27,7 +27,6 @@
 	const form = $derived(superForm(data.form, { validators: zod4Client(formSchema) }));
 	const { form: formData, enhance } = $derived(form);
 
-
 	const redirectTo = page.url.searchParams.get('redirectTo');
 </script>
 
@@ -113,7 +112,10 @@
 				</Form.Button>
 				<p class="text-muted-foreground text-center text-sm">
 					{m.already_account()}
-					<a href={resolve(redirectTo ? `/login?redirectTo=${redirectTo}` : '/register')} class="underline">{m.login()}</a>
+					<a
+						href={resolve(redirectTo ? `/login?redirectTo=${redirectTo}` : '/register')}
+						class="underline">{m.login()}</a
+					>
 				</p>
 			</form>
 		</div>

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -7,7 +7,6 @@ import { m } from '$lib/paraglide/messages';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals }) => {
-	// if (!locals.user) return redirect(302, '/');
 	return {
 		user: locals.user!,
 		enableForm: await superValidate(zod4(enableSchema)),

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -7,9 +7,9 @@ import { m } from '$lib/paraglide/messages';
 import type { Actions, PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals }) => {
-	if (!locals.user) return redirect(302, '/');
+	// if (!locals.user) return redirect(302, '/');
 	return {
-		user: locals.user,
+		user: locals.user!,
 		enableForm: await superValidate(zod4(enableSchema)),
 		verifyForm: await superValidate(zod4(verifySchema)),
 		disableForm: await superValidate(zod4(disableSchema))


### PR DESCRIPTION
## What

Move the check if the user is logged in to hooks.server.ts instead of checking on every pages.
Also add a redirection feature, so that if you want to access /settings, it will automatically redirect to /setting after login.

Closes #157

## How

Check is done on time in hooks.server.ts, the only allowed routes are /login /register /legal/terms and /legal/policy. 

## Checklist

- [ ] No unintended side effects
- [ ] Test with a prod build
