### PR TITLE
feat(game): leave button added

### DIFF
--- a/src/lib/game/phaser/scenes/gameScene/GameScene.ts
+++ b/src/lib/game/phaser/scenes/gameScene/GameScene.ts
@@ -15,7 +15,7 @@ import { createBackground, setupUI } from './setup';
 import { connectToServer } from './server';
 import { drawLastShotTrail, drawTrajectory } from './effects';
 import { updateWeaponUI } from './weaponUI';
-import { drawFireButton, drawChatButton, drawMoveButton } from './buttons';
+import { drawFireButton, drawChatButton, drawMoveButton, drawLeaveButton } from './buttons';
 import { updateFuelBar, updateHealthBar } from './hud';
 
 export default class GameScene extends Scene {
@@ -68,14 +68,20 @@ export default class GameScene extends Scene {
 	chatBtnW = 0;
 	chatBtnH = 0;
 	chatBtnHovered = false;
+	leaveBtn!: GameObjects.Graphics;
+	leaveBtnLabel!: GameObjects.Text;
+	leaveBtnCx = 0;
+	leaveBtnCy = 0;
+	leaveBtnW = 0;
+	leaveBtnH = 0;
+	leaveBtnHovered = false;
+	showingLeaveConfirm = false;
 	fuelBg!: GameObjects.Graphics;
 	fuelFill!: GameObjects.Graphics;
 	fuelIcon!: GameObjects.Text;
 	healthBg!: GameObjects.Graphics;
 	healthFill!: GameObjects.Graphics;
 	healthIcon!: GameObjects.Text;
-	controlsBg!: GameObjects.Graphics;
-	controlsText!: GameObjects.Text;
 	trajectoryGfx!: GameObjects.Graphics;
 	weaponUiGfx!: GameObjects.Graphics;
 	weaponNameLabel!: GameObjects.Text;
@@ -278,6 +284,7 @@ export default class GameScene extends Scene {
 		drawChatButton(this, this.chatBtnHovered);
 		drawMoveButton(this, 0, this.moveLeftBtnHovered && isMyTurn, !isMyTurn);
 		drawMoveButton(this, 1, this.moveRightBtnHovered && isMyTurn, !isMyTurn);
+		drawLeaveButton(this, this.leaveBtnHovered);
 
 		if (phase === 'AIMING' && currentPlayer === this.myPlayerIndex) {
 			const tankForTraj = { ...data.tanks[currentPlayer], turretAngle: this.localTurretAngle };
@@ -291,7 +298,7 @@ export default class GameScene extends Scene {
 			this.trajectoryGfx.clear();
 		}
 
-		if (phase !== 'OVER' && currentPlayer === this.myPlayerIndex) {
+		if (phase !== 'OVER' && currentPlayer === this.myPlayerIndex && !this.showingLeaveConfirm) {
 			this.handleInput(phase);
 		}
 	}

--- a/src/lib/game/phaser/scenes/gameScene/buttons.ts
+++ b/src/lib/game/phaser/scenes/gameScene/buttons.ts
@@ -1,6 +1,11 @@
 import { GameObjects } from 'phaser';
 
 interface ButtonsCtx {
+	leaveBtn: GameObjects.Graphics;
+	leaveBtnCx: number;
+	leaveBtnCy: number;
+	leaveBtnW: number;
+	leaveBtnH: number;
 	fireBtn: GameObjects.Graphics;
 	fireBtnLabel: GameObjects.Text;
 	fireBtnCx: number;
@@ -170,4 +175,35 @@ export function drawMoveButton(ctx: ButtonsCtx, side: 0 | 1, hovered: boolean, d
 	const shaftLeft = Math.min(baseX, shaftEndX);
 	const shaftRight = Math.max(baseX, shaftEndX);
 	g.fillRect(shaftLeft, cy - sw2, shaftRight - shaftLeft, sw2 * 2);
+}
+
+export function drawLeaveButton(ctx: ButtonsCtx, hovered: boolean) {
+	const g = ctx.leaveBtn;
+	g.clear();
+	const cx = ctx.leaveBtnCx;
+	const cy = ctx.leaveBtnCy;
+	const w = ctx.leaveBtnW;
+	const h = ctx.leaveBtnH;
+	const r = ctx.sw(5);
+
+	if (hovered) {
+		g.lineStyle(ctx.sw(4), 0xff2200, 0.18);
+		g.strokeRoundedRect(
+			cx - w / 2 - ctx.sw(2),
+			cy - h / 2 - ctx.sw(2),
+			w + ctx.sw(4),
+			h + ctx.sw(4),
+			r + ctx.sw(1)
+		);
+	}
+
+	g.fillStyle(hovered ? 0x2a0500 : 0x150200, 1);
+	g.fillRoundedRect(cx - w / 2, cy - h / 2, w, h, r);
+	g.lineStyle(ctx.sw(1.5), hovered ? 0xff3322 : 0x661100, 1);
+	g.strokeRoundedRect(cx - w / 2, cy - h / 2, w, h, r);
+	g.lineStyle(ctx.sw(1), 0xffffff, hovered ? 0.12 : 0.04);
+	g.beginPath();
+	g.moveTo(cx - w / 2 + r, cy - h / 2);
+	g.lineTo(cx + w / 2 - r, cy - h / 2);
+	g.strokePath();
 }

--- a/src/lib/game/phaser/scenes/gameScene/hud.ts
+++ b/src/lib/game/phaser/scenes/gameScene/hud.ts
@@ -64,3 +64,122 @@ export function showGameOver(scene: GameScene, winner: number) {
 		void scene.room?.leave();
 	});
 }
+
+export function showLeaveConfirm(scene: GameScene) {
+	scene.showingLeaveConfirm = true;
+
+	const w = scene.scale.width;
+	const h = scene.scale.height;
+
+	const overlay = scene.add.graphics().setDepth(30);
+	overlay.fillStyle(0x000000, 0.65);
+	overlay.fillRect(0, 0, w, h);
+
+	const blockZone = scene.add
+		.zone(w / 2, h / 2, w, h)
+		.setDepth(30)
+		.setInteractive();
+
+	const panelW = scene.sw(380);
+	const panelH = scene.sh(200);
+	const px = w / 2 - panelW / 2;
+	const py = h / 2 - panelH / 2;
+
+	const panel = scene.add.graphics().setDepth(31);
+	panel.fillStyle(COLORS.navy, 0.97);
+	panel.fillRoundedRect(px, py, panelW, panelH, scene.sw(8));
+	panel.lineStyle(1, COLORS.neonGlow, 0.35);
+	panel.strokeRoundedRect(px, py, panelW, panelH, scene.sw(8));
+
+	const title = scene.add
+		.text(w / 2, py + scene.sh(50), 'Leave the game?', {
+			fontSize: `${Math.round(scene.sh(26))}px`,
+			color: COLOR_STRINGS.white,
+			stroke: COLOR_STRINGS.navy,
+			strokeThickness: 4
+		})
+		.setOrigin(0.5)
+		.setDepth(32);
+
+	const subtitle = scene.add
+		.text(w / 2, py + scene.sh(95), 'You will forfeit the match.', {
+			fontSize: `${Math.round(scene.sh(16))}px`,
+			color: COLOR_STRINGS.red,
+			stroke: COLOR_STRINGS.navy,
+			strokeThickness: 3
+		})
+		.setOrigin(0.5)
+		.setDepth(32);
+
+	const btnW = scene.sw(130);
+	const btnH = scene.sh(44);
+	const btnY = py + scene.sh(155);
+	const stayCx = w / 2 - scene.sw(80);
+	const leaveCx = w / 2 + scene.sw(80);
+
+	const stayGfx = scene.add.graphics().setDepth(32);
+	stayGfx.fillStyle(0x0e1a0e, 1);
+	stayGfx.fillRoundedRect(stayCx - btnW / 2, btnY - btnH / 2, btnW, btnH, scene.sw(5));
+	stayGfx.lineStyle(scene.sw(1.5), 0x22aa44, 1);
+	stayGfx.strokeRoundedRect(stayCx - btnW / 2, btnY - btnH / 2, btnW, btnH, scene.sw(5));
+
+	const stayLabel = scene.add
+		.text(stayCx, btnY, 'STAY', {
+			fontSize: `${Math.round(scene.sh(16))}px`,
+			color: '#22cc55',
+			fontStyle: 'bold',
+			stroke: COLOR_STRINGS.navy,
+			strokeThickness: 3
+		})
+		.setOrigin(0.5)
+		.setDepth(33);
+
+	const leaveGfx = scene.add.graphics().setDepth(32);
+	leaveGfx.fillStyle(0x1a0500, 1);
+	leaveGfx.fillRoundedRect(leaveCx - btnW / 2, btnY - btnH / 2, btnW, btnH, scene.sw(5));
+	leaveGfx.lineStyle(scene.sw(1.5), 0xcc2211, 1);
+	leaveGfx.strokeRoundedRect(leaveCx - btnW / 2, btnY - btnH / 2, btnW, btnH, scene.sw(5));
+
+	const leaveConfirmLabel = scene.add
+		.text(leaveCx, btnY, 'LEAVE', {
+			fontSize: `${Math.round(scene.sh(16))}px`,
+			color: '#ff4433',
+			fontStyle: 'bold',
+			stroke: COLOR_STRINGS.navy,
+			strokeThickness: 3
+		})
+		.setOrigin(0.5)
+		.setDepth(33);
+
+	const stayZone = scene.add
+		.zone(stayCx, btnY, btnW, btnH)
+		.setDepth(33)
+		.setInteractive({ useHandCursor: true });
+
+	const leaveZone = scene.add
+		.zone(leaveCx, btnY, btnW, btnH)
+		.setDepth(33)
+		.setInteractive({ useHandCursor: true });
+
+	const dismiss = () => {
+		overlay.destroy();
+		blockZone.destroy();
+		panel.destroy();
+		title.destroy();
+		subtitle.destroy();
+		stayGfx.destroy();
+		stayLabel.destroy();
+		leaveGfx.destroy();
+		leaveConfirmLabel.destroy();
+		stayZone.destroy();
+		leaveZone.destroy();
+		scene.showingLeaveConfirm = false;
+	};
+
+	stayZone.on('pointerdown', dismiss);
+	leaveZone.on('pointerdown', () => {
+		dismiss();
+		void scene.room?.leave();
+		window.location.href = '/';
+	});
+}

--- a/src/lib/game/phaser/scenes/gameScene/hud.ts
+++ b/src/lib/game/phaser/scenes/gameScene/hud.ts
@@ -1,5 +1,7 @@
 import type GameScene from './GameScene';
 import { COLORS, COLOR_STRINGS } from '../../colors';
+import { resolve } from '$app/paths';
+import { goto } from '$app/navigation';
 
 export function updateFuelBar(scene: GameScene, fuel: number) {
 	scene.fuelFill.clear();
@@ -177,9 +179,9 @@ export function showLeaveConfirm(scene: GameScene) {
 	};
 
 	stayZone.on('pointerdown', dismiss);
-	leaveZone.on('pointerdown', () => {
+	leaveZone.on('pointerdown', async () => {
 		dismiss();
 		void scene.room?.leave();
-		window.location.href = '/';
+		await goto(resolve('/'));
 	});
 }

--- a/src/lib/game/phaser/scenes/gameScene/setup.ts
+++ b/src/lib/game/phaser/scenes/gameScene/setup.ts
@@ -8,6 +8,7 @@ import { ProjectileView } from '../../../client/view/ProjectileView';
 import { SpeechBubble } from '../../../client/view/speechBubble';
 import { ChatInput } from '../../../client/view/ChatInput';
 import { CHAT_BUBBLE_DURATION } from '$lib/game/shared/chatConfig';
+import { showLeaveConfirm } from './hud';
 
 export function createBackground(scene: Scene) {
 	const { width, height } = scene.scale;
@@ -249,28 +250,38 @@ export function setupUI(scene: GameScene) {
 		.setDepth(10)
 		.setVisible(false);
 
-	const boxW = scene.sw(190);
-	const boxH = scene.sh(100);
-	const boxX = scene.scale.width - scene.sw(0) - boxW;
-	const boxY = scene.scale.height - scene.sh(0) - boxH;
-	scene.controlsBg = scene.add.graphics().setDepth(10);
-	scene.controlsBg.fillStyle(COLORS.navy, 0.82);
-	scene.controlsBg.fillRect(boxX, boxY, boxW, boxH);
-	scene.controlsBg.lineStyle(1, COLORS.neonGlow, 0.3);
-	scene.controlsBg.strokeRect(boxX, boxY, boxW, boxH);
-	scene.controlsBg.setVisible(false);
+	scene.leaveBtnW = scene.sw(80);
+	scene.leaveBtnH = scene.sh(28);
+	scene.leaveBtnCx = scene.scale.width - scene.sw(48);
+	scene.leaveBtnCy = scene.scale.height - scene.sh(22);
 
-	scene.controlsText = scene.add
-		.text(boxX + scene.sw(8), boxY + scene.sh(18), '', {
-			fontSize: `${Math.round(scene.sh(11))}px`,
-			color: COLOR_STRINGS.white,
+	scene.leaveBtn = scene.add.graphics().setDepth(11).setVisible(false);
+	scene.leaveBtnLabel = scene.add
+		.text(scene.leaveBtnCx, scene.leaveBtnCy, 'LEAVE', {
+			fontSize: `${Math.round(scene.sh(12))}px`,
+			color: '#ff6655',
+			fontStyle: 'bold',
 			stroke: COLOR_STRINGS.navy,
-			strokeThickness: 2,
-			lineSpacing: scene.sh(4)
+			strokeThickness: 2
 		})
-		.setOrigin(0, 0)
-		.setDepth(10)
+		.setOrigin(0.5)
+		.setDepth(12)
 		.setVisible(false);
+
+	const leaveBtnZone = scene.add
+		.zone(scene.leaveBtnCx, scene.leaveBtnCy, scene.leaveBtnW, scene.leaveBtnH)
+		.setDepth(12)
+		.setInteractive({ useHandCursor: true });
+
+	leaveBtnZone.on('pointerover', () => {
+		scene.leaveBtnHovered = true;
+	});
+	leaveBtnZone.on('pointerout', () => {
+		scene.leaveBtnHovered = false;
+	});
+	leaveBtnZone.on('pointerdown', () => {
+		if (!scene.showingLeaveConfirm && scene.localPhase !== 'OVER') showLeaveConfirm(scene);
+	});
 }
 
 export function initViews(scene: GameScene) {
@@ -311,12 +322,11 @@ export function showGameUI(scene: GameScene) {
 	scene.healthIcon.setVisible(true);
 	scene.weaponUiGfx.setVisible(true);
 	scene.weaponNameLabel.setVisible(true);
-	scene.controlsText.setText(`Mouse  Aim + Power`);
-	scene.controlsBg.setVisible(true);
-	scene.controlsText.setVisible(true);
 	scene.fireBtn.setVisible(true);
 	scene.fireBtnLabel.setVisible(true);
 	scene.chatBtn.setVisible(true);
 	scene.moveLeftBtn.setVisible(true);
 	scene.moveRightBtn.setVisible(true);
+	scene.leaveBtn.setVisible(true);
+	scene.leaveBtnLabel.setVisible(true);
 }


### PR DESCRIPTION
## What

Added "LEAVE" button in the bottom right corner of the game screen. Clicking it opens a confirmation dialog with "STAY" and "LEAVE" buttons. Confirming leaves the Colyseus room and redirects to "/".

Closes #196

## How

First, I removed the area that was used to show the different keys that were usable in the bottom right corner.

Then, in Buttons.ts I added drawLeaveButton which draws the button graphics each frame (same pattern as fire/chat/move buttons) and in update(), calls drawLeaveButton every frame and guards handleInput with !this.showingLeaveConfirm so the player can't move or aim while the dialog is open.
 
In setup.ts --> Positions and creates the button graphics, label, and interactive zone in setupUI. The zone's pointerdown handler calls showLeaveConfirm — blocked if the confirm dialog is already open or if the game is over (localPhase === 'OVER'). showGameUI makes the button visible when the game starts.

And finally in Hud.ts I added showLeaveConfirm which creates the full overlay: a dimmed background, a blocking input zone, a panel with title and forfeit warning, and STAY/LEAVE buttons. STAY destroys all dialog elements and resets showingLeaveConfirm. LEAVE does the same then calls room.leave() and navigates to /.

## Checklist

- [x] No unintended side effects


<img width="480" height="540" alt="image" src="https://github.com/user-attachments/assets/e9370dfd-3e72-4e74-999e-8a4b9d9bc6a4" />

<img width="906" height="524" alt="image" src="https://github.com/user-attachments/assets/d9c0d45c-8e3b-4c75-96dc-65b64af156fc" />