### PR TITLE
feat/201 redesign end game window

### DIFF
--- a/src/lib/game/phaser/scenes/gameScene/GameScene.ts
+++ b/src/lib/game/phaser/scenes/gameScene/GameScene.ts
@@ -76,6 +76,7 @@ export default class GameScene extends Scene {
 	leaveBtnH = 0;
 	leaveBtnHovered = false;
 	showingLeaveConfirm = false;
+	dismissLeaveConfirm: (() => void) | null = null;
 	fuelBg!: GameObjects.Graphics;
 	fuelFill!: GameObjects.Graphics;
 	fuelIcon!: GameObjects.Text;

--- a/src/lib/game/phaser/scenes/gameScene/GameScene.ts
+++ b/src/lib/game/phaser/scenes/gameScene/GameScene.ts
@@ -20,7 +20,6 @@ import { updateFuelBar, updateHealthBar } from './hud';
 
 export default class GameScene extends Scene {
 	room: Room<GameRoomState>;
-	returningToLobby = false;
 	myPlayerIndex: 0 | 1 = 0;
 
 	roomReady = false;

--- a/src/lib/game/phaser/scenes/gameScene/hud.ts
+++ b/src/lib/game/phaser/scenes/gameScene/hud.ts
@@ -25,45 +25,74 @@ export function updateHealthBar(scene: GameScene, health: number) {
 }
 
 export function showGameOver(scene: GameScene, winner: number) {
+	// If the player had the leave-confirm window open, close it so the two
+	// modals don't overlap when the opponent leaves / the game ends.
+	scene.dismissLeaveConfirm?.();
+
+	const w = scene.scale.width;
+	const h = scene.scale.height;
+
+	const overlay = scene.add.graphics().setDepth(30);
+	overlay.fillStyle(0x000000, 0.65);
+	overlay.fillRect(0, 0, w, h);
+
+	// Block clicks from reaching the game behind the overlay.
 	scene.add
-		.graphics()
-		.setDepth(20)
-		.fillStyle(COLORS.navy, 0.88)
-		.fillRect(
-			scene.scale.width / 2 - scene.sw(350),
-			scene.scale.height / 2 - scene.sh(110),
-			scene.sw(700),
-			scene.sh(220)
-		);
+		.zone(w / 2, h / 2, w, h)
+		.setDepth(30)
+		.setInteractive();
+
+	const panelW = scene.sw(420);
+	const panelH = scene.sh(220);
+	const px = w / 2 - panelW / 2;
+	const py = h / 2 - panelH / 2;
+
+	const panel = scene.add.graphics().setDepth(31);
+	panel.fillStyle(COLORS.navy, 0.97);
+	panel.fillRoundedRect(px, py, panelW, panelH, scene.sw(8));
+	panel.lineStyle(1, COLORS.neonGlow, 0.35);
+	panel.strokeRoundedRect(px, py, panelW, panelH, scene.sw(8));
 
 	scene.add
-		.text(
-			scene.scale.width / 2,
-			scene.scale.height / 2 - scene.sh(70),
-			`${scene.playerNames[winner]} Wins!`,
-			{
-				fontSize: `${Math.round(scene.sh(52))}px`,
-				color: COLOR_STRINGS.gold,
-				stroke: COLOR_STRINGS.navy,
-				strokeThickness: 6
-			}
-		)
-		.setOrigin(0.5)
-		.setDepth(21);
-
-	scene.add
-		.text(scene.scale.width / 2, scene.scale.height / 2 + scene.sh(20), 'Press R to play again', {
-			fontSize: `${Math.round(scene.sh(22))}px`,
-			color: COLOR_STRINGS.neonGlow,
+		.text(w / 2, py + scene.sh(85), `${scene.playerNames[winner]} Wins!`, {
+			fontSize: `${Math.round(scene.sh(46))}px`,
+			color: COLOR_STRINGS.gold,
 			stroke: COLOR_STRINGS.navy,
-			strokeThickness: 4
+			strokeThickness: 6
 		})
 		.setOrigin(0.5)
-		.setDepth(21);
+		.setDepth(32);
 
-	scene.input.keyboard!.once('keydown-R', () => {
-		scene.returningToLobby = true;
+	const btnW = scene.sw(190);
+	const btnH = scene.sh(48);
+	const btnCx = w / 2;
+	const btnY = py + scene.sh(160);
+
+	const homeGfx = scene.add.graphics().setDepth(32);
+	homeGfx.fillStyle(0x0a1430, 1);
+	homeGfx.fillRoundedRect(btnCx - btnW / 2, btnY - btnH / 2, btnW, btnH, scene.sw(5));
+	homeGfx.lineStyle(scene.sw(1.5), COLORS.neonGlow, 1);
+	homeGfx.strokeRoundedRect(btnCx - btnW / 2, btnY - btnH / 2, btnW, btnH, scene.sw(5));
+
+	scene.add
+		.text(btnCx, btnY, 'RETURN HOME', {
+			fontSize: `${Math.round(scene.sh(16))}px`,
+			color: COLOR_STRINGS.neonGlow,
+			fontStyle: 'bold',
+			stroke: COLOR_STRINGS.navy,
+			strokeThickness: 3
+		})
+		.setOrigin(0.5)
+		.setDepth(33);
+
+	const homeZone = scene.add
+		.zone(btnCx, btnY, btnW, btnH)
+		.setDepth(33)
+		.setInteractive({ useHandCursor: true });
+
+	homeZone.on('pointerdown', async () => {
 		void scene.room?.leave();
+		await goto(resolve('/'));
 	});
 }
 
@@ -176,7 +205,9 @@ export function showLeaveConfirm(scene: GameScene) {
 		stayZone.destroy();
 		leaveZone.destroy();
 		scene.showingLeaveConfirm = false;
+		scene.dismissLeaveConfirm = null;
 	};
+	scene.dismissLeaveConfirm = dismiss;
 
 	stayZone.on('pointerdown', dismiss);
 	leaveZone.on('pointerdown', async () => {

--- a/src/lib/game/phaser/scenes/gameScene/server.ts
+++ b/src/lib/game/phaser/scenes/gameScene/server.ts
@@ -63,12 +63,7 @@ function setupRoomHandlers(scene: GameScene, room: Room<GameRoomState>) {
 	});
 
 	room.onLeave.once(() => {
-		if (scene.returningToLobby) {
-			scene.returningToLobby = false;
-			scene.scene.restart();
-		} else {
-			scene.statusText.setText('Disconnected').setVisible(true);
-		}
+		scene.statusText.setText('Disconnected').setVisible(true);
 	});
 
 	room.onMessage('chat', (data: { playerIndex: number; text: string }) => {
@@ -79,7 +74,6 @@ function setupRoomHandlers(scene: GameScene, room: Room<GameRoomState>) {
 
 export function connectToServer(scene: GameScene) {
 	scene.roomReady = false;
-	scene.returningToLobby = false;
 	scene.tankSprites = null;
 	scene.terrainView = null;
 	scene.projView = null;
@@ -181,12 +175,7 @@ export function connectToServer(scene: GameScene) {
 		});
 
 		room.onLeave.once(() => {
-			if (scene.returningToLobby) {
-				scene.returningToLobby = false;
-				scene.scene.restart();
-			} else {
-				scene.statusText.setText('Disconnected').setVisible(true);
-			}
+			scene.statusText.setText('Disconnected').setVisible(true);
 		});
 
 		setupRoomHandlers(scene, room);


### PR DESCRIPTION
## What

This PR redesigns the end-game window.
The old game-over screen was a flat panel that told you the winner and required pressing **R** to play again. It's now a proper modal that's matching the existing leave-confirm dialog that shows the winner and offers a single clickable **RETURN HOME** button. The `R` keyboard shortcut and its associated "return to lobby / restart scene" flow have been removed entirely.

Closes #201

## How

- hud.ts, showGameOver: 
Rebuilt to mirror 'showLeaveConfirm' pattern full-screen dark overlay, an interactive block zone so clicks can't reach the game behind it, a rounded navy panel with a neon border, the "{winner} Wins!" title, and a single RETURN HOME button that calls 'room.leave()' then navigates to '/'.

- Removed the 'R' key:
Dropped the 'keydown-R' handler and the "Press R to play again" text.

- Modal overlap fix: 
If a player has the leave-confirm window open when the opponent leaves (game ends), both modals would stack. 'showGameOver' now calls 'scene.dismissLeaveConfirm?.()' first. To enable this, 'showLeaveConfirm' stores its teardown closure on the scene (dismissLeaveConfirm) and clears it on close.

- Dead-code cleanup: removed the now-unused 'returningToLobby' flag from 'GameScene', its reset in 'connectToServer', and the 'scene.restart()' branch in both 'room.onLeave.once' handlers (they now just show "Disconnected").

- You can look at src/lib/game/phaser/scenes/gameScene/hud.ts 'showGameOver' vs 'showLeaveConfirm'
  the styling/structure is intentionally parallel.

- The reverse overlap case is already safe:
  confirming "LEAVE" in your own window navigates away before any game-over window would render.


## Checklist

- [x] No unintended side effects
