### PR TITLE
feat(backend): add redirect if already logged

### DIFF
--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,7 +1,7 @@
 {
 	"private": true,
 	"dependencies": {
-		"@actions/core": "^1.10.1",
-		"@actions/github": "^6.0.0"
+		"@actions/core": "^1.11.1",
+		"@actions/github": "^6.0.1"
 	}
 }

--- a/src/routes/login/+page.server.ts
+++ b/src/routes/login/+page.server.ts
@@ -1,0 +1,8 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = ({ locals }) => {
+	if (locals.user) {
+		return redirect(303, '/');
+	}
+};

--- a/src/routes/register/+page.server.ts
+++ b/src/routes/register/+page.server.ts
@@ -6,7 +6,10 @@ import { formSchema } from './schema';
 import { m } from '$lib/paraglide/messages';
 import type { Actions, PageServerLoad } from './$types';
 
-export const load: PageServerLoad = async () => {
+export const load: PageServerLoad = async ({ locals }) => {
+	if (locals.user) {
+		return redirect(303, '/');
+	}
 	return { form: await superValidate(zod4(formSchema)) };
 };
 


### PR DESCRIPTION
## What

Redirect authenticated users away from auth pages (`/login`, `/register`) to the home page.

Closes #203

## How

Added a `load` function in `src/routes/login/+page.server.ts` (new file) and updated the existing `load` in `src/routes/register/+page.server.ts` to check `locals.user`. If a session is already present, a `303` redirect to `/` is thrown before the page renders.

The existing `handleRouteProtection` hook in `hooks.server.ts` only guards protected routes from unauthenticated users — it does not handle the inverse case. This PR fills that gap at the page level, keeping the logic scoped to the two concerned routes.

## Checklist

- [ ] No unintended side effects — `PUBLIC_ROUTES` in `hooks.server.ts` is unchanged; unauthenticated users can still reach `/login` and `/register` normally