### PR TITLE
fix(shared): Game canvas scaling fixed

### DIFF
--- a/src/lib/components/GameWindow.svelte
+++ b/src/lib/components/GameWindow.svelte
@@ -3,28 +3,51 @@
 	import { syncFromCSS } from '$lib/game/phaser/colors';
 	import type { GameRoomState } from '$lib/game/colyseus/schema/GameRoomState';
 	import type { Room } from '@colyseus/sdk';
+	import type { Game } from 'phaser';
 
 	let { room }: { room: Room<GameRoomState> } = $props();
 
 	onMount(() => {
-		let observer: MutationObserver | undefined;
+		let themeObserver: MutationObserver | undefined;
+		let resizeObserver: ResizeObserver | undefined;
+		let game: Game | undefined;
 
 		void (async () => {
 			const { default: StartGame } = await import('$lib/game/phaser/game');
 			const { EventBus } = await import('$lib/game/phaser/EventBus');
 
 			syncFromCSS();
-			StartGame('game-container', room);
+			game = StartGame('game-container', room);
 
-			observer = new MutationObserver(() => {
+			// Refit the Phaser canvas whenever its container changes size — covers
+			// window resizes and the initial hidden -> visible transition, which
+			// Scale.FIT alone doesn't pick up.
+			const container = document.getElementById('game-container');
+			if (container) {
+				resizeObserver = new ResizeObserver(() => game?.scale.refresh());
+				resizeObserver.observe(container);
+			}
+
+			themeObserver = new MutationObserver(() => {
 				syncFromCSS();
 				EventBus.emit('theme-changed');
 			});
-			observer.observe(document.documentElement, { attributeFilter: ['class'] });
+			themeObserver.observe(document.documentElement, { attributeFilter: ['class'] });
 		})();
 
-		return () => observer?.disconnect();
+		return () => {
+			themeObserver?.disconnect();
+			resizeObserver?.disconnect();
+			game?.destroy(true);
+		};
 	});
 </script>
 
 <div id="game-container"></div>
+
+<style>
+	#game-container {
+		width: 100%;
+		height: 100%;
+	}
+</style>

--- a/src/routes/game/[[id]]/+page.svelte
+++ b/src/routes/game/[[id]]/+page.svelte
@@ -82,7 +82,10 @@
 
 {#key room}
 	{#if room}
-		<div class={!started ? 'hidden' : ''}>
+		<!-- Kept laid out (full size) but hidden until the match starts, so Phaser
+		     boots against a correctly-sized container. `absolute inset-0` keeps it
+		     out of flow so the lobby underneath is unaffected. -->
+		<div class="absolute inset-0 {!started ? 'invisible' : ''}">
 			<GameWindow {room} />
 		</div>
 	{/if}


### PR DESCRIPTION
## What

Fixes the game canvas not tracking the window size. 

Closes #207

## How

Phaser's `Scale.FIT` was measuring a container with no real size:  'game-container' had no dimensions (height collapsed onto the canvas it was sizing), and the game boots while its wrapper is still hidden.

- game-container is now '100%' inside an 'absolute inset-0' wrapper, so `FIT` measures the viewport box, not the canvas.
- 'ResizeObserver' calls 'game.scale.refresh()' on size changes (window resize + hidden→visible).
- Cleanup: 'GameWindow' now 'destroy()'s the 'Game' on unmount.

## Checklist


- [x] No unintended side effects
