### PR TITLE
fix(game): resolve phaser warnings

### DIFF
--- a/src/lib/game/phaser/commonGameConfig.ts
+++ b/src/lib/game/phaser/commonGameConfig.ts
@@ -1,0 +1,25 @@
+import { Scale, WEBGL, type Types } from 'phaser';
+
+const DEFAULT_WIDTH = 1920;
+const DEFAULT_HEIGHT = 1080;
+
+export const commonGameConfig: Types.Core.GameConfig = {
+    type: WEBGL,
+    scale: {
+        mode: Scale.FIT,
+        autoCenter: Scale.CENTER_BOTH,
+        width: DEFAULT_WIDTH,
+        height: DEFAULT_HEIGHT
+    },
+    banner: false,
+    audio: {
+        noAudio: true,
+        disableWebAudio: true
+    },
+    disableContextMenu: true,
+    render: {
+        premultipliedAlpha: false,
+        pixelArt: false,
+        transparent: true,
+    },
+};

--- a/src/lib/game/phaser/commonGameConfig.ts
+++ b/src/lib/game/phaser/commonGameConfig.ts
@@ -4,22 +4,22 @@ const DEFAULT_WIDTH = 1920;
 const DEFAULT_HEIGHT = 1080;
 
 export const commonGameConfig: Types.Core.GameConfig = {
-    type: WEBGL,
-    scale: {
-        mode: Scale.FIT,
-        autoCenter: Scale.CENTER_BOTH,
-        width: DEFAULT_WIDTH,
-        height: DEFAULT_HEIGHT
-    },
-    banner: false,
-    audio: {
-        noAudio: true,
-        disableWebAudio: true
-    },
-    disableContextMenu: true,
-    render: {
-        premultipliedAlpha: false,
-        pixelArt: false,
-        transparent: true,
-    },
+	type: WEBGL,
+	scale: {
+		mode: Scale.FIT,
+		autoCenter: Scale.CENTER_BOTH,
+		width: DEFAULT_WIDTH,
+		height: DEFAULT_HEIGHT
+	},
+	banner: false,
+	audio: {
+		noAudio: true,
+		disableWebAudio: true
+	},
+	disableContextMenu: true,
+	render: {
+		premultipliedAlpha: false,
+		pixelArt: false,
+		transparent: true
+	}
 };

--- a/src/lib/game/phaser/game.ts
+++ b/src/lib/game/phaser/game.ts
@@ -1,23 +1,14 @@
 import GameScene from './scenes/gameScene/GameScene';
-import { AUTO, Scale, Game } from 'phaser';
+import { Game } from 'phaser';
 import type { Room } from '@colyseus/sdk';
 import type { GameRoomState } from '$lib/game/colyseus/schema/GameRoomState';
-
-const DEFAULT_WIDTH = 1920;
-const DEFAULT_HEIGHT = 1080;
+import { commonGameConfig } from './commonGameConfig';
 
 const StartGame = (parent: string, room: Room<GameRoomState>) => {
 	return new Game({
-		type: AUTO,
-		scale: {
-			mode: Scale.FIT,
-			autoCenter: Scale.CENTER_BOTH,
-			width: DEFAULT_WIDTH,
-			height: DEFAULT_HEIGHT
-		},
+		...commonGameConfig,
 		scene: [new GameScene({ room: room })],
-		transparent: true,
-		parent
+		parent,
 	});
 };
 

--- a/src/lib/game/phaser/game.ts
+++ b/src/lib/game/phaser/game.ts
@@ -8,7 +8,7 @@ const StartGame = (parent: string, room: Room<GameRoomState>) => {
 	return new Game({
 		...commonGameConfig,
 		scene: [new GameScene({ room: room })],
-		parent,
+		parent
 	});
 };
 

--- a/src/lib/game/phaser/lobbyGame.ts
+++ b/src/lib/game/phaser/lobbyGame.ts
@@ -1,19 +1,9 @@
 import DemoScene from './scenes/demoScene';
-import { AUTO, Scale, Game, type Types } from 'phaser';
-
-const config: Types.Core.GameConfig = {
-	type: AUTO,
-	scale: {
-		mode: Scale.FIT,
-		autoCenter: Scale.CENTER_BOTH,
-		width: 1920,
-		height: 1080
-	},
-	scene: [DemoScene]
-};
+import { commonGameConfig } from './commonGameConfig';
+import { Game } from 'phaser';
 
 const StartLobbyGame = (parent: string) => {
-	return new Game({ ...config, transparent: true, parent });
+	return new Game({ ...commonGameConfig, scene: [DemoScene], parent });
 };
 
 export default StartLobbyGame;


### PR DESCRIPTION
## What

This removes the Audio warning and the useless banner from the two Phaser Game instances.
Also unified the GameConfig of the two Game instance in a single file.
Sadly the WebGL warning cannot be solved see [#5602](https://github.com/phaserjs/phaser/issues/5602)

Closes #219