### PR TITLE
fix(back): omit security infos from the public profile page api

### DIFF
--- a/src/routes/profile/[id]/+page.server.ts
+++ b/src/routes/profile/[id]/+page.server.ts
@@ -5,7 +5,8 @@ import { m } from '$lib/paraglide/messages';
 
 export const load: PageServerLoad = async ({ params }) => {
 	const user = await db.user.findUnique({
-		where: { id: params.id }
+		where: { id: params.id },
+		omit: { twoFactorEnabled: true, emailVerified: true },
 	});
 	if (!user) return error(404, m.no_user());
 	return { userProfile: user };

--- a/src/routes/profile/[id]/+page.server.ts
+++ b/src/routes/profile/[id]/+page.server.ts
@@ -6,7 +6,7 @@ import { m } from '$lib/paraglide/messages';
 export const load: PageServerLoad = async ({ params }) => {
 	const user = await db.user.findUnique({
 		where: { id: params.id },
-		omit: { twoFactorEnabled: true, emailVerified: true },
+		omit: { twoFactorEnabled: true, emailVerified: true }
 	});
 	if (!user) return error(404, m.no_user());
 	return { userProfile: user };


### PR DESCRIPTION
## What

Omit twoFactorEnabled and emailVerified from the /profile/id load function,
so that it doesn't leak to other users.

Closes #226

## How

Use prisma `omit:` field to exclude data.

