### PR TITLE
Fix/243 improve in game text readability

### DIFF
--- a/src/lib/game/client/view/TankSprite.ts
+++ b/src/lib/game/client/view/TankSprite.ts
@@ -18,7 +18,7 @@ export class TankSprite {
 		this.healthGfx = scene.add.graphics();
 		this.nameLabel = scene.add
 			.text(state.x, state.y - 48, state.name, {
-				fontSize: '12px',
+				fontSize: '16px',
 				color: COLOR_STRINGS.white,
 				stroke: COLOR_STRINGS.black,
 				strokeThickness: 3
@@ -41,7 +41,7 @@ export class TankSprite {
 		const hx = x + HULL_H * Math.sin(slope);
 		const hy = y - HULL_H * Math.cos(slope);
 
-		this.nameLabel.setPosition(hx, hy - 31);
+		this.nameLabel.setPosition(hx, hy - 56);
 		this.drawBody(x, y, color, facing, slope);
 		this.drawBarrel(hx, hy, color, turretAngle);
 		this.drawHealth(hx, hy, health);
@@ -226,7 +226,7 @@ export class TankSprite {
 		const w = 44,
 			h = 5;
 		const bx = hx - w / 2,
-			by = hy - 22;
+			by = hy - 42;
 		this.healthGfx.fillStyle(COLORS.black, 0.6);
 		this.healthGfx.fillRect(bx - 1, by - 1, w + 2, h + 2);
 		const pct = health / 100;

--- a/src/lib/game/phaser/commonGameConfig.ts
+++ b/src/lib/game/phaser/commonGameConfig.ts
@@ -18,7 +18,10 @@ export const commonGameConfig: Types.Core.GameConfig = {
 	},
 	disableContextMenu: true,
 	render: {
-		premultipliedAlpha: false,
+		// premultipliedAlpha must stay at its default (true): Phaser's WebGL
+		// pipeline outputs premultiplied alpha, and on a transparent canvas
+		// `false` makes the compositor apply alpha twice, darkening every
+		// semi-transparent effect (aiming cone, trails, stars, glows).
 		pixelArt: false,
 		transparent: true
 	}

--- a/src/lib/game/phaser/scenes/gameScene/setup.ts
+++ b/src/lib/game/phaser/scenes/gameScene/setup.ts
@@ -242,8 +242,8 @@ export function setupUI(scene: GameScene) {
 	scene.weaponUiGfx = scene.add.graphics().setDepth(10).setVisible(false);
 	scene.weaponNameLabel = scene.add
 		.text(0, 0, '', {
-			fontSize: `${Math.round(scene.sh(11))}px`,
-			color: COLOR_STRINGS.yellow,
+			fontSize: `${Math.round(scene.sh(14))}px`,
+			color: COLOR_STRINGS.white,
 			stroke: COLOR_STRINGS.navy,
 			strokeThickness: 3
 		})

--- a/src/lib/game/phaser/scenes/gameScene/weaponUI.ts
+++ b/src/lib/game/phaser/scenes/gameScene/weaponUI.ts
@@ -39,6 +39,9 @@ export function updateWeaponUI(ctx: WeaponUICtx, activeIndex: number, isMyTurn =
 
 	const myCooldowns = ctx.weaponCooldowns[ctx.myPlayerIndex] ?? [];
 
+	const labelTypeIdx = isMyTurn ? ctx.hoveredWeaponTypeIdx : -1;
+	if (labelTypeIdx === -1) ctx.weaponNameLabel.setText('');
+
 	ctx.selectableWeaponIndices.forEach((typeIdx, si) => {
 		const cx = startX + si * (iSize + iGap) + half;
 		const cy = iconY;
@@ -109,12 +112,12 @@ export function updateWeaponUI(ctx: WeaponUICtx, activeIndex: number, isMyTurn =
 			ctx.weaponUiGfx.strokePath();
 		}
 
-		if (active) {
+		if (typeIdx === labelTypeIdx) {
 			const label = weaponDisplayName(type.name).toUpperCase();
 			ctx.weaponNameLabel
-				.setPosition(cx, cy - half - ctx.sh(10))
+				.setPosition(cx, cy - half - ctx.sh(30))
 				.setText(onCooldown ? msg.game_weapon_used({ name: label }) : label)
-				.setFontSize(Math.round(ctx.sh(11)));
+				.setFontSize(Math.round(ctx.sh(14)));
 		}
 
 		if (!isMyTurn) {


### PR DESCRIPTION
## What

- Color : 
 Removed premultipliedAlpha: false from the render config (added by PR #220), leaving Phaser's default of true. "premultipliedAlpha: false" told the browser compositor the transparent canvas held straight alpha. The compositor therefore multiplied by alpha a second time, dimming every semi-transparent pixel to roughly alpha².
 
- WeaponName :
The weapon name label above the weapon bar now appears only when you hover an icon, only on your turn, no longer when a weapon is selected.

- PlayerName/Healthbar
 Moved the in-world tank UI up and enlarged the player name.

Closes #243 

## Checklist

- [ ] No unintended side effects
