### PR TITLE
fix(front): Fix blur background when joining game with sidebar open

### DIFF
--- a/src/lib/components/FriendList.svelte
+++ b/src/lib/components/FriendList.svelte
@@ -43,8 +43,19 @@
 			.catch((e) => {
 				console.error(e);
 			});
+		const handleClickOutside = (e: MouseEvent) => {
+			const sidebar = document.getElementById('friend-sidebar');
+			const target = e.target as Node;
+			if (sidebar && !sidebar.contains(target)) {
+				friendListOpen.set(false);
+			}
+		};
+
+		document.addEventListener('click', handleClickOutside, true);
+
 		return () => {
 			disconnect();
+			document.removeEventListener('click', handleClickOutside, true);
 		};
 	});
 </script>


### PR DESCRIPTION
## What

Fixed the blur issue when joining a game with sidebar open (on mobile)

Closes #233 

## How

Using a handle click, that detect a click (The click was cancelled if we are clicking on a notification, bc we are setting stop propagation to true.)

## Checklist

- [ ] Work fine (on small screen).
