### PR TITLE
fix(game): destroy colyseus room at the end of the game

### DIFF
--- a/src/lib/game/colyseus/TankRoom.ts
+++ b/src/lib/game/colyseus/TankRoom.ts
@@ -145,6 +145,7 @@ export class TankRoom extends Room<{ state: GameRoomState }> {
 				reason: 'forfeit'
 			});
 			void this.lock();
+			void this.disconnect();
 		}
 	}
 
@@ -416,6 +417,7 @@ export class TankRoom extends Room<{ state: GameRoomState }> {
 				winner
 			});
 			void this.lock();
+			void this.disconnect();
 			return true;
 		}
 		return false;


### PR DESCRIPTION
## What

Disconnect from room when a client quit or when someone win.

Closes #229

## How

Adds a `this.disconnect();`

## Checklist

- [ ] No unintended side effects
