### PR TITLE
security/227-validate-colyseus-payloads

### DIFF
--- a/src/lib/game/colyseus/TankRoom.ts
+++ b/src/lib/game/colyseus/TankRoom.ts
@@ -7,6 +7,16 @@ import { PROJECTILE_TYPES, AIRSTRIKE_TYPE_INDEX } from '$lib/game/shared/project
 import type { GameState } from '$lib/game/shared/state/GameState';
 import type { TankState } from '$lib/game/shared/state/TankState';
 import { registerChatHandler } from '$lib/game/colyseus/handlers/chatHandler';
+import {
+	InputSchema,
+	FireDirectSchema,
+	SetTurretAngleSchema,
+	SelectWeaponSchema,
+	ReadySchema,
+	RoomOptionsSchema,
+	type InputMessage as InputState
+} from '$lib/game/colyseus/messageSchemas';
+import { validated } from '$lib/game/colyseus/validateMessage';
 
 const activePlayers = new Set<string>();
 
@@ -16,11 +26,6 @@ const MOVE_SPEED = 100;
 const MAX_SLOPE_ANGLE = 80;
 const MAX_FUEL_DISTANCE = 200;
 const TANK_X: [number, number] = [180, 1740];
-
-type InputState = {
-	moveLeft: boolean;
-	moveRight: boolean;
-};
 
 export class TankRoom extends Room<{ state: GameRoomState }> {
 	private physicsState!: GameState;
@@ -33,70 +38,86 @@ export class TankRoom extends Room<{ state: GameRoomState }> {
 	private playerIds: [string, string] = ['', ''];
 	private playersReady: [boolean, boolean] = [false, false];
 
-	async onCreate(options: { private: boolean } = { private: false }) {
+	async onCreate(options: unknown = {}) {
 		this.maxClients = 2;
 		this.patchRate = 16;
 		this.setState(new GameRoomState());
 
-		if (options.private) {
+		const opts = RoomOptionsSchema.safeParse(options);
+		if (opts.success && opts.data.private) {
 			await this.setPrivate();
 		}
 
-		this.onMessage<InputState>('input', (client, data) => {
-			if (this.isCurrentPlayer(client)) {
-				this.inputs.set(client.sessionId, data);
-			}
-		});
+		this.onMessage(
+			'input',
+			validated(InputSchema, (client, data) => {
+				if (this.isCurrentPlayer(client)) {
+					this.inputs.set(client.sessionId, data);
+				}
+			})
+		);
 
-		this.onMessage('fire_direct', (client, data: { angle: number; power: number }) => {
-			if (!this.isCurrentPlayer(client)) return;
-			if (this.physicsState?.phase !== 'AIMING') return;
-			const p = this.physicsState.currentPlayer;
-			if (this.physicsState.weaponCooldowns[p][this.physicsState.weaponIndex]) return;
-			const tank = this.physicsState.tanks[p];
-			tank.turretAngle = data.angle;
-			this.clampTurretAngle(p);
-			this.physicsState.power = Math.max(0, Math.min(100, data.power));
-			this.fireProjectile();
-		});
+		this.onMessage(
+			'fire_direct',
+			validated(FireDirectSchema, (client, data) => {
+				if (!this.isCurrentPlayer(client)) return;
+				if (this.physicsState?.phase !== 'AIMING') return;
+				const p = this.physicsState.currentPlayer;
+				if (this.physicsState.weaponCooldowns[p][this.physicsState.weaponIndex]) return;
+				const tank = this.physicsState.tanks[p];
+				tank.turretAngle = data.angle;
+				this.clampTurretAngle(p);
+				this.physicsState.power = Math.max(0, Math.min(100, data.power));
+				this.fireProjectile();
+			})
+		);
 
-		this.onMessage('set_turret_angle', (client, data: { angle: number }) => {
-			if (!this.isCurrentPlayer(client)) return;
-			if (this.physicsState?.phase !== 'AIMING') return;
-			const p = this.physicsState.currentPlayer;
-			const tank = this.physicsState.tanks[p];
-			tank.turretAngle = data.angle;
-			this.clampTurretAngle(p);
-		});
+		this.onMessage(
+			'set_turret_angle',
+			validated(SetTurretAngleSchema, (client, data) => {
+				if (!this.isCurrentPlayer(client)) return;
+				if (this.physicsState?.phase !== 'AIMING') return;
+				const p = this.physicsState.currentPlayer;
+				const tank = this.physicsState.tanks[p];
+				tank.turretAngle = data.angle;
+				this.clampTurretAngle(p);
+			})
+		);
 
-		this.onMessage('select_weapon', (client, data: { index: number }) => {
-			if (!this.isCurrentPlayer(client)) return;
-			if (this.physicsState?.phase !== 'AIMING') return;
-			const p = this.physicsState.currentPlayer;
-			const type = PROJECTILE_TYPES[data.index];
-			if (!type || type.selectable === false) return;
-			if (this.physicsState.weaponCooldowns[p][data.index]) return;
-			this.physicsState.weaponIndex = data.index;
-			this.state.weaponIndex = data.index;
-		});
+		this.onMessage(
+			'select_weapon',
+			validated(SelectWeaponSchema, (client, data) => {
+				if (!this.isCurrentPlayer(client)) return;
+				if (this.physicsState?.phase !== 'AIMING') return;
+				const p = this.physicsState.currentPlayer;
+				const type = PROJECTILE_TYPES[data.index];
+				if (!type || type.selectable === false) return;
+				if (this.physicsState.weaponCooldowns[p][data.index]) return;
+				this.physicsState.weaponIndex = data.index;
+				this.state.weaponIndex = data.index;
+			})
+		);
 
-		this.onMessage('ready', (client) => {
-			const idx = this.getPlayerIndex(client);
-			if (idx !== undefined) this.playersReady[idx] = true;
+		this.onMessage(
+			'ready',
+			validated(ReadySchema, (client) => {
+				const idx = this.getPlayerIndex(client);
+				if (idx !== undefined) this.playersReady[idx] = true;
 
-			if (this.playersReady.every((v) => v)) {
-				if (this.gameStarted) {
-					this.sendGameStartOnReconnect(client);
-				} else {
-					try {
-						console.log('[TankRoom] initGame() OK, phase =', this.state.phase);
-						this.initGame();
-					} catch (e) {
-						console.error('[TankRoom] initGame() threw:', e);
+				if (this.playersReady.every((v) => v)) {
+					if (this.gameStarted) {
+						this.sendGameStartOnReconnect(client);
+					} else {
+						try {
+							console.log('[TankRoom] initGame() OK, phase =', this.state.phase);
+							this.initGame();
+						} catch (e) {
+							console.error('[TankRoom] initGame() threw:', e);
+						}
 					}
 				}
-			}
-		});
+			})
+		);
 
 		this.setSimulationInterval((dt) => this.tick(dt), 1000 / 60);
 		// register chat handler

--- a/src/lib/game/colyseus/handlers/chatHandler.ts
+++ b/src/lib/game/colyseus/handlers/chatHandler.ts
@@ -1,5 +1,7 @@
 import type { Room, Client } from 'colyseus';
 import { CHAT_BUBBLE_DURATION } from '$lib/game/shared/chatConfig';
+import { ChatSchema } from '$lib/game/colyseus/messageSchemas';
+import { validated } from '$lib/game/colyseus/validateMessage';
 
 export function registerChatHandler(
 	room: Room,
@@ -7,8 +9,9 @@ export function registerChatHandler(
 ) {
 	const lastMessage = new Map<string, number>(); // anti-spam
 
-	room.onMessage('chat', (client: Client, data: { text: string }) => {
-		try {
+	room.onMessage(
+		'chat',
+		validated(ChatSchema, (client, data) => {
 			const playerIndex = getPlayerIndex(client);
 			if (playerIndex === undefined) return;
 
@@ -16,14 +19,9 @@ export function registerChatHandler(
 			const last = lastMessage.get(client.sessionId) ?? 0;
 			if (now - last < CHAT_BUBBLE_DURATION) return;
 
-			const text = String(data.text).trim().slice(0, 80);
-			if (!text) return;
-
 			lastMessage.set(client.sessionId, now);
 
-			room.broadcast('chat', { playerIndex, text });
-		} catch (err) {
-			console.error('[chatHandler] error:', err);
-		}
-	});
+			room.broadcast('chat', { playerIndex, text: data.text });
+		})
+	);
 }

--- a/src/lib/game/colyseus/messageSchemas.ts
+++ b/src/lib/game/colyseus/messageSchemas.ts
@@ -1,0 +1,41 @@
+import { z } from 'zod';
+import { PROJECTILE_TYPES } from '$lib/game/shared/projectileTypes';
+
+// Runtime validation for every client → server Colyseus payload. The
+// TypeScript types on the handlers are compile-time only; any client can
+// send arbitrary data over the WebSocket, so each message is checked
+// against its schema before the handler logic runs.
+
+export const InputSchema = z.object({
+	moveLeft: z.boolean(),
+	moveRight: z.boolean()
+});
+export type InputMessage = z.infer<typeof InputSchema>;
+
+export const FireDirectSchema = z.object({
+	angle: z.number().finite(),
+	power: z.number().finite().min(0).max(100)
+});
+
+export const SetTurretAngleSchema = z.object({
+	angle: z.number().finite()
+});
+
+export const SelectWeaponSchema = z.object({
+	index: z
+		.number()
+		.int()
+		.min(0)
+		.max(PROJECTILE_TYPES.length - 1)
+});
+
+export const ChatSchema = z.object({
+	text: z.string().trim().min(1).max(80)
+});
+
+// 'ready' carries no payload
+export const ReadySchema = z.union([z.undefined(), z.null(), z.object({}).strict()]);
+
+export const RoomOptionsSchema = z.object({
+	private: z.boolean().optional()
+});

--- a/src/lib/game/colyseus/validateMessage.ts
+++ b/src/lib/game/colyseus/validateMessage.ts
@@ -1,0 +1,24 @@
+import type { Client } from 'colyseus';
+import type { z } from 'zod';
+
+/**
+ * Wraps a Colyseus message handler with Zod validation: invalid payloads
+ * are logged and dropped before they can reach the handler logic, so every
+ * message is rejected the same way.
+ */
+export function validated<S extends z.ZodType>(
+	schema: S,
+	handler: (client: Client, data: z.infer<S>) => void
+): (client: Client, data: unknown) => void {
+	return (client, data) => {
+		const result = schema.safeParse(data);
+		if (!result.success) {
+			console.warn(
+				`[validation] rejected message from ${client.sessionId}:`,
+				result.error.issues[0]?.message ?? 'invalid payload'
+			);
+			return;
+		}
+		handler(client, result.data);
+	};
+}


### PR DESCRIPTION
## What

All six client->server messages (input, fire_direct, set_turret_angle, select_weapon, ready, chat) are now checked against Zod schemas before their handlers run. 

Invalid payloads (NaN angles, out-of-range indexes, oversized chat, wrong types) are logged and dropped consistently via a shared validated() wrapper. Room creation options are validated too.

Closes #227 

## How

- messageSchema.ts: 

one Zod schema per message: input (two booleans), fire_direct (finite angle, power 0–100), set_turret_angle (finite angle), select_weapon (integer index bounded by PROJECTILE_TYPES.length), chat (trimmed string, 1–80 chars), ready (no payload), plus RoomOptionsSchema for the room-creation options.

- ValidateMessages.ts

the validated(schema, handler) wrapper: safeParse on every incoming message, log + drop on failure, and the handler receives the parsed data (unknown extra keys stripped), typed via z.infer so the handler signatures need no manual annotations.

- Tankroom.ts : 

all five handlers wrapped; handler bodies are byte-for-byte the same logic as before. The local InputState type is now imported from the schema (z.infer), so the runtime check and the type can't drift. onCreate also validates its client-supplied options instead of trusting { private: boolean }.

- chatHandler.ts : 

ChatSchema replaces the manual String(data.text).trim().slice(0, 80); the anti-spam timer stays. The try/catch is gone since the only thing it guarded against (malformed data) is now rejected before the handler runs.


## Checklist

- [ ] No unintended side effects

<img width="385" height="122" alt="Screenshot from 2026-06-12 19-55-49" src="https://github.com/user-attachments/assets/f3cda1f4-c3e1-4f3e-a098-bf2d5ef83a2a" />


<img width="668" height="102" alt="Nan_logs" src="https://github.com/user-attachments/assets/7dc46e99-97db-47bb-809f-3f3e05f4953c" />
