### PR TITLE
docs(shared): update all project documentation to match codebase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,101 @@
+# Changelog
+
+All notable changes to Transcendance are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+This project does not use versioned releases yet — changes are grouped by category.
+
+---
+
+## [Unreleased]
+
+### Infrastructure
+- CI/CD pipeline with 10 required status checks (lint, typecheck, test, docker build)
+- GitHub Actions automation: labels, branch status, PR state tracking
+- 29 labels across type, scope, status, and priority categories
+- Issue templates (10 YAML templates) with scope dropdown and task checklists
+- PR template with checklist and size limits
+- Docker and Docker Compose deployment with Caddy reverse proxy on port 4443
+- Makefile for local setup (certs, envfile, up/down/fclean)
+- Docusaurus documentation site deployed on GitHub Pages
+
+### Authentication
+- Better-Auth with SvelteKit integration
+- OAuth 2.0 via 42 intranet
+- Google OAuth provider with username collision handling
+- TOTP two-factor authentication (enable, scan, disable)
+- Session injection and route protection via SvelteKit hooks
+- Hidden TOTP for Google-connected accounts
+- Redirect already-logged-in users away from login/register pages
+- Security: sensitive fields omitted from public profile API
+
+### Frontend
+- Svelte 5 (runes mode) with SvelteKit 2
+- TailwindCSS 4 with shadcn-svelte component library (accordion, alert-dialog, badge, button, card, checkbox, dialog, form, input, label, separator, sheet, skeleton, sonner, tabs, tooltip)
+- Dark/light theme with shader-based transitions
+- Homepage, login, register, profile, settings, legal (terms/privacy), error pages
+- Avatar upload and display with edge case handling
+- Friend system: add, accept, pending zone, live friend list updates
+- Real-time notification system (toasts for invites, friend requests)
+- Game lobby UI with invite notifications
+- Language picker with Paraglide i18n (English, French, Spanish)
+- Responsive design across all pages
+- Show password checkbox on login/register
+- Account deletion from settings
+- Change password from settings
+
+### Game
+- Phaser 4 engine embedded in SvelteKit via a game window component
+- Colyseus 0.17 authoritative multiplayer server (in-process, shared port 3000)
+- Tank-based combat: movement, aiming, projectiles with balanced damage and trajectories
+- Weapons: multiple types with reworked design and balancing
+- Terrain system: destructible and indestructible terrain with physics
+- Real-time chat in battle with dynamic sizing
+- SSR support for game canvas
+- Game reconnection after disconnect
+- Opponent disconnect game-over state with i18n message
+- Room cleanup: Colyseus room destroyed at game end
+- Online status tracking (StatusRoom)
+- Invitation system: invite friends to games with notification
+- Leave button during game
+- End game window redesign
+- Fuel and projectile info hidden from opponent view
+- Game colors synced with frontend theme (light/dark mode auto-switch)
+- Resolution scaling improvements
+- i18n in game UI
+- Phaser warnings resolved
+- Colyseus message payloads validated with Zod
+
+### Backend
+- Express 5 + SvelteKit in single process (index.ts)
+- Prisma 7 ORM with SQLite (better-sqlite3)
+- Database schema: User, Session, Account, Verification, FriendRequest, TwoFactor
+- Friend system CRUD with live updates via notifications
+- Route protection with public route allowlist
+- Colyseus rooms defined and registered in hooks.server.ts
+- Database seeding script
+
+### Shared
+- Realtime notification system between users (Colyseus-based)
+- Online presence/status tracking
+- Game state, physics, and terrain logic shared across client and server
+- Game colors theme sync
+- Avatar serving from uploads directory
+- Game invite notification delivery
+
+### Developer Experience
+- pnpm workspace with strict engine and build allowlist
+- ESLint (recommendedTypeChecked) + Prettier (tabs, single quotes, trailing comma none)
+- Prisma format in lint pipeline
+- svelte-check + tsc --noEmit unified typecheck
+- Vite dev server with custom colyseus-dev-server plugin
+- Hot module replacement alongside WebSocket game traffic
+- Conventional Commits with 10 types and 8 scopes
+- Squash-merge only on main, branch naming with issue numbers
+- Dead code cleaned up, Gamescene.ts split into focused files
+
+---
+
+## Contributing
+
+See [docs/engineering-guidelines.md](docs/engineering-guidelines.md) for commit format, branch naming, PR workflow, and code standards.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project does not use versioned releases yet — changes are grouped by cate
 ## [Unreleased]
 
 ### Infrastructure
+
 - CI/CD pipeline with 10 required status checks (lint, typecheck, test, docker build)
 - GitHub Actions automation: labels, branch status, PR state tracking
 - 29 labels across type, scope, status, and priority categories
@@ -20,6 +21,7 @@ This project does not use versioned releases yet — changes are grouped by cate
 - Docusaurus documentation site deployed on GitHub Pages
 
 ### Authentication
+
 - Better-Auth with SvelteKit integration
 - OAuth 2.0 via 42 intranet
 - Google OAuth provider with username collision handling
@@ -30,6 +32,7 @@ This project does not use versioned releases yet — changes are grouped by cate
 - Security: sensitive fields omitted from public profile API
 
 ### Frontend
+
 - Svelte 5 (runes mode) with SvelteKit 2
 - TailwindCSS 4 with shadcn-svelte component library (accordion, alert-dialog, badge, button, card, checkbox, dialog, form, input, label, separator, sheet, skeleton, sonner, tabs, tooltip)
 - Dark/light theme with shader-based transitions
@@ -45,6 +48,7 @@ This project does not use versioned releases yet — changes are grouped by cate
 - Change password from settings
 
 ### Game
+
 - Phaser 4 engine embedded in SvelteKit via a game window component
 - Colyseus 0.17 authoritative multiplayer server (in-process, shared port 3000)
 - Tank-based combat: movement, aiming, projectiles with balanced damage and trajectories
@@ -67,6 +71,7 @@ This project does not use versioned releases yet — changes are grouped by cate
 - Colyseus message payloads validated with Zod
 
 ### Backend
+
 - Express 5 + SvelteKit in single process (index.ts)
 - Prisma 7 ORM with SQLite (better-sqlite3)
 - Database schema: User, Session, Account, Verification, FriendRequest, TwoFactor
@@ -76,6 +81,7 @@ This project does not use versioned releases yet — changes are grouped by cate
 - Database seeding script
 
 ### Shared
+
 - Realtime notification system between users (Colyseus-based)
 - Online presence/status tracking
 - Game state, physics, and terrain logic shared across client and server
@@ -84,6 +90,7 @@ This project does not use versioned releases yet — changes are grouped by cate
 - Game invite notification delivery
 
 ### Developer Experience
+
 - pnpm workspace with strict engine and build allowlist
 - ESLint (recommendedTypeChecked) + Prettier (tabs, single quotes, trailing comma none)
 - Prisma format in lint pipeline

--- a/README.md
+++ b/README.md
@@ -2,16 +2,16 @@
 
 Multiplayer browser game — SvelteKit + Colyseus + Phaser 4.
 
-| Layer | Technology |
-|-------|-----------|
-| Frontend | SvelteKit 2, Svelte 5 (runes), TailwindCSS 4, shadcn-svelte |
-| Game engine | Phaser 4 |
-| Multiplayer | Colyseus 0.17 (in-process, shared port 3000) |
-| Auth | Better-Auth |
-| Database | Prisma 7 + SQLite (better-sqlite3) |
-| i18n | Paraglide JS |
-| Package manager | pnpm 10.33.0 |
-| Runtime | Node 24.15.0 |
+| Layer           | Technology                                                  |
+| --------------- | ----------------------------------------------------------- |
+| Frontend        | SvelteKit 2, Svelte 5 (runes), TailwindCSS 4, shadcn-svelte |
+| Game engine     | Phaser 4                                                    |
+| Multiplayer     | Colyseus 0.17 (in-process, shared port 3000)                |
+| Auth            | Better-Auth                                                 |
+| Database        | Prisma 7 + SQLite (better-sqlite3)                          |
+| i18n            | Paraglide JS                                                |
+| Package manager | pnpm 10.33.0                                                |
+| Runtime         | Node 24.15.0                                                |
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,94 @@
-# 42 Transcendance
+# Transcendance
 
-`git clone "URL" <project>`
+Multiplayer browser game — SvelteKit + Colyseus + Phaser 4.
 
-`cd <project>`
+| Layer | Technology |
+|-------|-----------|
+| Frontend | SvelteKit 2, Svelte 5 (runes), TailwindCSS 4, shadcn-svelte |
+| Game engine | Phaser 4 |
+| Multiplayer | Colyseus 0.17 (in-process, shared port 3000) |
+| Auth | Better-Auth |
+| Database | Prisma 7 + SQLite (better-sqlite3) |
+| i18n | Paraglide JS |
+| Package manager | pnpm 10.33.0 |
+| Runtime | Node 24.15.0 |
 
-`pnpm install`
+## Quickstart
 
-`pnpm generate`
+### Docker
 
-`pnpm db:push`
+```bash
+git clone https://github.com/ketodin/transcendance.git
+cd transcendance
+make          # generates certs, envfile, starts Docker Compose
+```
 
-For dev `pnpm run dev`
+This starts two containers: the app (port 3000) and Caddy (port 4443 with TLS). Open https://localhost:4443.
+
+### Bare metal
+
+```bash
+git clone https://github.com/ketodin/transcendance.git
+cd transcendance
+pnpm install
+cp .env.example .env      # fill in BETTER_AUTH_URL and ORIGIN
+pnpm generate              # Prisma client + Paraglide i18n
+pnpm db:push               # create dev.db
+pnpm dev                   # http://localhost:3000
+```
+
+**System dependencies:** `build-essential` and `python3` are required for `better-sqlite3` native compilation.
+
+### Production (without Docker)
+
+```bash
+pnpm build   # build SvelteKit app
+pnpm start   # tsx index.ts — one process on port 3000
+```
+
+## Project Structure
+
+```
+transcendance/
+├── src/
+│   ├── routes/                    # SvelteKit routes (login, register, profile, game, settings, legal)
+│   ├── lib/
+│   │   ├── components/            # UI components (shadcn-svelte, Avatar, FriendList, GameWindow, TOTP...)
+│   │   ├── game/
+│   │   │   ├── client/view/       # Client-side rendering (ChatInput, ProjectileView, TankSprite, TerrainView)
+│   │   │   ├── colyseus/          # Authoritative server (TankRoom, StatusRoom, schemas, handlers, validation)
+│   │   │   ├── phaser/scenes/     # Phaser 4 game scenes (demoScene, gameScene)
+│   │   │   └── shared/            # Shared logic (state, physics, terrain, projectile types)
+│   │   ├── server/                # Backend utilities (auth client, Prisma db client)
+│   │   ├── hooks/                 # Client hooks (is-mobile)
+│   │   └── stores/                # Svelte stores (sidebar)
+│   ├── hooks.server.ts            # Hook chain: Paraglide → Better-Auth → Colyseus → Route Protection
+│   └── app.d.ts                   # Type declarations
+├── prisma/schema.prisma           # Database schema (User, Session, Account, FriendRequest, TwoFactor...)
+├── messages/                      # i18n translations (en.json, fr.json, es.json)
+├── docs/                          # Architecture, runbook, engineering guidelines, ADRs
+├── .github/                       # CI workflows, issue/PR templates, automation scripts
+├── docusaurus/                    # Documentation site (serves docs/ automatically)
+├── compose.yaml                   # Docker Compose (app + Caddy)
+├── index.ts                       # Production entrypoint (Express + SvelteKit + Colyseus)
+├── Makefile                       # Local setup shortcuts (make, make up, make down)
+├── CHANGELOG.md                   # Project history
+└── README.md
+```
+
+## Documentation
+
+- [Architecture Overview](docs/architecture.md) — stack, process model, scope map, hook chain
+- [Runbook](docs/runbook.md) — bootstrap, day-to-day commands, CI debugging, resets
+- [Engineering Guidelines](docs/engineering-guidelines.md) — code style, commit format, branch naming, PR workflow, CI/CD
+- [Architecture Decision Records](docs/adr/) — 9 ADRs covering every major architectural choice
+- [Changelog](CHANGELOG.md) — all notable changes organized by category
+
+## Contributing
+
+See [docs/engineering-guidelines.md](docs/engineering-guidelines.md) for the full workflow. Quick summary:
+
+- Branch naming: `<type>/<issue-number>-<slug>` (issue required before branching)
+- Commit format: `<type>(<scope>): <description>` (Conventional Commits, scope required, 10 types, 8 scopes)
+- Squash merge only, never push directly to `main`
+- All 10 CI checks must pass before merge

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,152 @@
+# Architecture Overview
+
+SvelteKit + Colyseus + Prisma monorepo for a multiplayer browser game.
+
+## Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Frontend | SvelteKit 2, Svelte 5 (runes), TailwindCSS 4, shadcn-svelte |
+| Game engine | Phaser 4 |
+| Multiplayer | Colyseus 0.17 (authoritative server, in-process with SvelteKit) |
+| Auth | Better-Auth |
+| Database | Prisma 7 + SQLite (better-sqlite3) |
+| i18n | Paraglide JS |
+| Package manager | pnpm 10.33.0 |
+| Runtime | Node 24.15.0 |
+
+## Process Model
+
+Colyseus runs inside the same Node.js process as SvelteKit — **not** as a separate service.
+
+- **Development:** custom Vite plugin (`colyseus-dev-server`) attaches Colyseus to Vite's HTTP server, correctly routing WebSocket upgrade events (HMR vs. Colyseus traffic)
+- **Production:** `index.ts` creates a single Express + HTTP server shared by SvelteKit and Colyseus via `WebSocketTransport`
+- **Port:** 3000 for both. No separate process, no port 2567.
+
+## Docker Stack
+
+`compose.yaml` defines two services:
+
+| Service | Role | Port |
+|---------|------|------|
+| transcendance | SvelteKit + Colyseus app | 3000 (internal) |
+| caddy | Reverse proxy with TLS termination | 4443 (external) |
+
+Caddy handles TLS certificate provisioning. Clients connect to `https://<host>:4443`.
+
+The app container runs `entrypoint.sh` on startup: it pushes the Prisma schema to the database and symlinks the avatar directory to `static/uploads/`. The database file and avatar storage are persisted via a Docker volume at `./data/`.
+
+## Hook Chain
+
+`src/hooks.server.ts` sequences four hooks in this order:
+
+```
+handleColyseus → handleParaglide → handleBetterAuth → handleRouteProtection
+```
+
+1. **handleColyseus** — registers Colyseus room types (`tank_room`, `status`) via `matchMaker.defineRoomType`. Uses `globalThis.gameServer` to prevent double-initialization across HMR reloads.
+2. **handleParaglide** — determines locale from the request, injects `%paraglide.lang%` and `%paraglide.dir%` placeholders into the HTML shell.
+3. **handleBetterAuth** — attaches the user session to `event.locals` via Better-Auth. On API auth routes, hands off to the Better-Auth SvelteKit handler.
+4. **handleRouteProtection** — redirects unauthenticated users away from protected routes (everything except `/login`, `/register`, and `favicon.png`).
+
+## Game Server
+
+All Colyseus code under `src/lib/game/colyseus/`:
+
+```
+src/lib/game/colyseus/
+├── TankRoom.ts              # Main game room — tank combat
+├── StatusRoom.ts            # Online presence tracking room
+├── statusHub.ts             # Status broadcast utility
+├── messageSchemas.ts        # Zod schemas for all Colyseus messages
+├── validateMessage.ts       # Message validation dispatch
+├── handlers/
+│   └── chatHandler.ts       # In-game chat message handling
+└── schema/
+    ├── GameRoomState.ts     # Top-level room state
+    ├── StatusRoomState.ts   # Online status state
+    ├── TankSchema.ts        # Tank entity schema
+    ├── TerrainSchema.ts     # Terrain entity schema
+    └── ProjectileSchema.ts  # Projectile entity schema
+```
+
+### Phaser Client
+
+Client-side game rendering under `src/lib/game/`:
+
+```
+src/lib/game/
+├── client/view/             # Client-side Phaser objects
+│   ├── ChatInput.ts         # In-game chat input
+│   ├── ProjectileView.ts    # Projectile rendering
+│   ├── speechBubble.ts      # Chat bubble rendering
+│   ├── TankSprite.ts        # Tank rendering
+│   └── TerrainView.ts       # Terrain rendering
+├── phaser/
+│   ├── game.ts              # Phaser game factory
+│   ├── lobbyGame.ts         # Lobby scene
+│   ├── EventBus.ts          # Phaser ↔ Svelte event bridge
+│   ├── colors.ts            # Theme-synced color constants
+│   ├── commonGameConfig.ts  # Shared Phaser config
+│   └── scenes/
+│       ├── demoScene.ts     # Demo/title scene
+│       └── gameScene/       # Main gameplay scene (split into focused modules)
+│           ├── GameScene.ts
+│           ├── buttons.ts
+│           ├── effects.ts
+│           ├── hud.ts
+│           ├── server.ts
+│           ├── setup.ts
+│           ├── types.ts
+│           └── weaponUI.ts
+└── shared/                  # Shared logic across client and server
+    ├── state/               # State definitions (GameState, TankState, ProjectileState, TerrainState)
+    ├── logic/               # Game rules (physics, terrain)
+    ├── chatConfig.ts        # Chat constants
+    └── projectileTypes.ts   # Projectile type definitions
+```
+
+### Rooms
+
+Two Colyseus room types are registered in `hooks.server.ts`:
+
+| Room type | Class | Purpose |
+|-----------|-------|---------|
+| `tank_room` | `TankRoom` | Main game room — tank combat, chat, state sync |
+| `status` | `StatusRoom` | Online presence tracking for friend list |
+
+Room types are defined once via `globalThis.gameServer` guard to survive HMR reloads.
+
+## Scope Map
+
+| Scope | Covers |
+|-------|--------|
+| `frontend` | SvelteKit routes, Svelte components, shadcn-svelte, Vite config |
+| `backend` | Server-side services, API routes, hooks.server.ts |
+| `auth` | OAuth 42, Google OAuth, JWT, TOTP, session injection |
+| `game` | Phaser engine, Colyseus rooms, schemas, game logic |
+| `db` | Prisma schema, migrations, database client, queries |
+| `shared` | Code in `src/lib/game/shared/` used by both client and Colyseus server |
+| `infra` | Docker, compose.yaml, Caddy, deployment, .github |
+| `i18n` | Paraglide translations, messages.json |
+
+`auth` is intentionally separate from `backend`: auth issues are security-sensitive, span the frontend/backend boundary, and require a distinct resolution path.
+
+## CI/CD
+
+6 required status checks on `main`:
+
+| Check | What it runs |
+|-------|-------------|
+| `ci-lint-eslint` | `pnpm lint:eslint` |
+| `ci-lint-prettier` | `pnpm lint:prettier` |
+| `ci-lint-prisma` | `prisma format --check` |
+| `ci-typecheck-game-server` | `pnpm typecheck` (svelte-check + tsc --noEmit, unified) |
+| `ci-docker-build` | Build Dockerfile via `compose.yaml` (no push) |
+| `ci-docs-deploy` | Docusaurus deploy to GitHub Pages (main only, on docs/docusaurus changes) |
+
+Squash-merge only. All checks must pass. 1 required approval minimum.
+
+4 automation workflows manage labels (`automation-label-issue`, `automation-label-pr`) and issue status (`automation-state-branch`, `automation-state-pr`).
+
+See [engineering-guidelines.md](engineering-guidelines.md) for the full workflow specification. See [docs/adr/](adr/) for the 9 Architecture Decision Records.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,16 +4,16 @@ SvelteKit + Colyseus + Prisma monorepo for a multiplayer browser game.
 
 ## Stack
 
-| Layer | Technology |
-|-------|-----------|
-| Frontend | SvelteKit 2, Svelte 5 (runes), TailwindCSS 4, shadcn-svelte |
-| Game engine | Phaser 4 |
-| Multiplayer | Colyseus 0.17 (authoritative server, in-process with SvelteKit) |
-| Auth | Better-Auth |
-| Database | Prisma 7 + SQLite (better-sqlite3) |
-| i18n | Paraglide JS |
-| Package manager | pnpm 10.33.0 |
-| Runtime | Node 24.15.0 |
+| Layer           | Technology                                                      |
+| --------------- | --------------------------------------------------------------- |
+| Frontend        | SvelteKit 2, Svelte 5 (runes), TailwindCSS 4, shadcn-svelte     |
+| Game engine     | Phaser 4                                                        |
+| Multiplayer     | Colyseus 0.17 (authoritative server, in-process with SvelteKit) |
+| Auth            | Better-Auth                                                     |
+| Database        | Prisma 7 + SQLite (better-sqlite3)                              |
+| i18n            | Paraglide JS                                                    |
+| Package manager | pnpm 10.33.0                                                    |
+| Runtime         | Node 24.15.0                                                    |
 
 ## Process Model
 
@@ -27,10 +27,10 @@ Colyseus runs inside the same Node.js process as SvelteKit — **not** as a sepa
 
 `compose.yaml` defines two services:
 
-| Service | Role | Port |
-|---------|------|------|
-| transcendance | SvelteKit + Colyseus app | 3000 (internal) |
-| caddy | Reverse proxy with TLS termination | 4443 (external) |
+| Service       | Role                               | Port            |
+| ------------- | ---------------------------------- | --------------- |
+| transcendance | SvelteKit + Colyseus app           | 3000 (internal) |
+| caddy         | Reverse proxy with TLS termination | 4443 (external) |
 
 Caddy handles TLS certificate provisioning. Clients connect to `https://<host>:4443`.
 
@@ -110,25 +110,25 @@ src/lib/game/
 
 Two Colyseus room types are registered in `hooks.server.ts`:
 
-| Room type | Class | Purpose |
-|-----------|-------|---------|
-| `tank_room` | `TankRoom` | Main game room — tank combat, chat, state sync |
-| `status` | `StatusRoom` | Online presence tracking for friend list |
+| Room type   | Class        | Purpose                                        |
+| ----------- | ------------ | ---------------------------------------------- |
+| `tank_room` | `TankRoom`   | Main game room — tank combat, chat, state sync |
+| `status`    | `StatusRoom` | Online presence tracking for friend list       |
 
 Room types are defined once via `globalThis.gameServer` guard to survive HMR reloads.
 
 ## Scope Map
 
-| Scope | Covers |
-|-------|--------|
-| `frontend` | SvelteKit routes, Svelte components, shadcn-svelte, Vite config |
-| `backend` | Server-side services, API routes, hooks.server.ts |
-| `auth` | OAuth 42, Google OAuth, JWT, TOTP, session injection |
-| `game` | Phaser engine, Colyseus rooms, schemas, game logic |
-| `db` | Prisma schema, migrations, database client, queries |
-| `shared` | Code in `src/lib/game/shared/` used by both client and Colyseus server |
-| `infra` | Docker, compose.yaml, Caddy, deployment, .github |
-| `i18n` | Paraglide translations, messages.json |
+| Scope      | Covers                                                                 |
+| ---------- | ---------------------------------------------------------------------- |
+| `frontend` | SvelteKit routes, Svelte components, shadcn-svelte, Vite config        |
+| `backend`  | Server-side services, API routes, hooks.server.ts                      |
+| `auth`     | OAuth 42, Google OAuth, JWT, TOTP, session injection                   |
+| `game`     | Phaser engine, Colyseus rooms, schemas, game logic                     |
+| `db`       | Prisma schema, migrations, database client, queries                    |
+| `shared`   | Code in `src/lib/game/shared/` used by both client and Colyseus server |
+| `infra`    | Docker, compose.yaml, Caddy, deployment, .github                       |
+| `i18n`     | Paraglide translations, messages.json                                  |
 
 `auth` is intentionally separate from `backend`: auth issues are security-sensitive, span the frontend/backend boundary, and require a distinct resolution path.
 
@@ -136,14 +136,14 @@ Room types are defined once via `globalThis.gameServer` guard to survive HMR rel
 
 6 required status checks on `main`:
 
-| Check | What it runs |
-|-------|-------------|
-| `ci-lint-eslint` | `pnpm lint:eslint` |
-| `ci-lint-prettier` | `pnpm lint:prettier` |
-| `ci-lint-prisma` | `prisma format --check` |
-| `ci-typecheck-game-server` | `pnpm typecheck` (svelte-check + tsc --noEmit, unified) |
-| `ci-docker-build` | Build Dockerfile via `compose.yaml` (no push) |
-| `ci-docs-deploy` | Docusaurus deploy to GitHub Pages (main only, on docs/docusaurus changes) |
+| Check                      | What it runs                                                              |
+| -------------------------- | ------------------------------------------------------------------------- |
+| `ci-lint-eslint`           | `pnpm lint:eslint`                                                        |
+| `ci-lint-prettier`         | `pnpm lint:prettier`                                                      |
+| `ci-lint-prisma`           | `prisma format --check`                                                   |
+| `ci-typecheck-game-server` | `pnpm typecheck` (svelte-check + tsc --noEmit, unified)                   |
+| `ci-docker-build`          | Build Dockerfile via `compose.yaml` (no push)                             |
+| `ci-docs-deploy`           | Docusaurus deploy to GitHub Pages (main only, on docs/docusaurus changes) |
 
 Squash-merge only. All checks must pass. 1 required approval minimum.
 

--- a/docs/engineering-guidelines.md
+++ b/docs/engineering-guidelines.md
@@ -378,11 +378,11 @@ Every workflow:
 
 ### 7.2 CI Triggers by Branch Prefix
 
-| Branch prefix          | CI on push                  |
-| ---------------------- | --------------------------- |
-| `feat`, `fix`, `chore` | Lint, typecheck             |
-| `ci`, `infra`          | Docker build                |
-| All other prefixes     | Full CI on PR to `main`     |
+| Branch prefix          | CI on push              |
+| ---------------------- | ----------------------- |
+| `feat`, `fix`, `chore` | Lint, typecheck         |
+| `ci`, `infra`          | Docker build            |
+| All other prefixes     | Full CI on PR to `main` |
 
 Full CI runs on every PR to `main`.
 
@@ -467,14 +467,14 @@ clampExpiry(duration, MAX_TOKEN_EXPIRY_MS);
 
 ### 9.2 Required Documents
 
-| File                             | Purpose                                              |
-| -------------------------------- | ---------------------------------------------------- |
-| `README.md`                      | Project description, setup instructions, stack, links |
+| File                             | Purpose                                                    |
+| -------------------------------- | ---------------------------------------------------------- |
+| `README.md`                      | Project description, setup instructions, stack, links      |
 | `docs/architecture.md`           | High-level architecture, file trees, scope map, hook chain |
-| `docs/engineering-guidelines.md` | This file                                            |
-| `docs/runbook.md`                | Operational procedures                               |
-| `docs/adr/`                      | Architecture Decision Records                        |
-| `CHANGELOG.md`                   | Notable changes per release                          |
+| `docs/engineering-guidelines.md` | This file                                                  |
+| `docs/runbook.md`                | Operational procedures                                     |
+| `docs/adr/`                      | Architecture Decision Records                              |
+| `CHANGELOG.md`                   | Notable changes per release                                |
 
 ### 9.3 What to Document
 

--- a/docs/engineering-guidelines.md
+++ b/docs/engineering-guidelines.md
@@ -21,16 +21,9 @@
 
 ## 1. Overview
 
-This is a SvelteKit + Colyseus + Prisma monorepo (`ft-transcendence`). The stack includes:
+This is the Transcendance multiplayer browser game — SvelteKit + Colyseus + Phaser 4 + Prisma.
 
-- **Frontend:** SvelteKit 2 · Svelte 5 (runes mode) · TailwindCSS 4 · shadcn-svelte
-- **Backend:** Express 5 · Colyseus 0.17 (game server, bundled into SvelteKit via Vite) · Better-Auth
-- **Database:** Prisma 7 + SQLite (better-sqlite3)
-- **i18n:** Paraglide JS
-- **Package manager:** `pnpm 10.33.0`
-- **Runtime:** Node 24
-
-> **Architecture note:** Colyseus runs inside the same Node.js process as SvelteKit — not as a separate service. In development, a custom Vite plugin (`colyseus-dev-server`) attaches Colyseus to Vite's HTTP server. In production, `server.ts` creates a single Express + HTTP server shared by SvelteKit and Colyseus (`WebSocketTransport`). Both use **port 3000**. There is no separate game-server process, no port 2567, and no `devserver` / `devall` scripts.
+See [architecture.md](architecture.md) for the full stack, process model, file tree, scope map, hook chain, and CI gate list. This document focuses on the **rules**: coding standards, Git workflow, review process, testing, security, and tooling.
 
 **Non-negotiable rules:**
 
@@ -159,49 +152,31 @@ pnpm db:studio     # prisma studio
 
 ## 3. Architecture & Design Principles
 
+The full architecture — stack, process model, file tree, scope map, hook chain, and CI gates — lives in [architecture.md](architecture.md). This section covers the design principles that apply to every contribution.
+
 ### 3.1 Layered Separation
 
 - Clearly separate UI, business logic, data access, and external integrations.
 - No circular imports.
 - A shared vocabulary for domain concepts — no four different names for the same thing.
 
-### 3.2 Scope Map
+### 3.2 Architecture Decision Records (ADRs)
 
-| Scope      | What it covers                                                      |
-| ---------- | ------------------------------------------------------------------- |
-| `frontend` | SvelteKit routes, Svelte components, shadcn-svelte, Vite config     |
-| `backend`  | Server-side services, API routes, `hooks.server.ts`                 |
-| `auth`     | OAuth 42, JWT, TOTP, session injection                              |
-| `game`     | Phaser engine, Colyseus rooms, schemas, game logic                  |
-| `db`       | Prisma schema, migrations, database client, queries                 |
-| `shared`   | `packages/game-shared` — code used by both game-server and frontend |
-| `infra`    | Docker, `compose.yaml`, deployment, `.github`                       |
-| `i18n`     | Paraglide translations, `messages.json`                             |
-
-`auth` is intentionally separate from `backend`: auth issues are security-sensitive, span the frontend/backend boundary, and require a distinct resolution path.
-
-### 3.3 Game Server Layout
-
-All Colyseus server-side code lives under `src/lib/game/colyseus/`:
+Any architectural decision with lasting impact must be documented as an ADR. 9 ADRs exist in `docs/adr/` covering every major decision:
 
 ```
-src/lib/game/colyseus/
-├── TankRoom.ts          # Room definition — registered in hooks.server.ts
-└── schema/              # GameRoomState, TankSchema, TerrainSchema, ProjectileSchema
+docs/adr/adr-001-sveltekit-as-fullstack-framework.md
+docs/adr/adr-002-phaser-4-game.md
+docs/adr/adr-003-prisma-orm.md
+docs/adr/adr-004-sqlite-database-and-better-sqlite3.md
+docs/adr/adr-005-paraglidejs-for-internationalization.md
+docs/adr/adr-006-colyseus-for-real-time-multiplayer.md
+docs/adr/adr-007-better-auth-for-authentication.md
+docs/adr/adr-008-shared-lib-game-modules-across-client-and-server.md
+docs/adr/adr-009-docker-compose-for-deployment.md
 ```
 
-- Rooms are registered via `matchMaker.defineRoomType('tankroom', TankRoom)` inside the `handleColyseus` hook in `src/hooks.server.ts`.
-- `globalThis.gameServer` guards against double-initialisation across HMR reloads.
-- Client connections use `ws://localhost:3000` in development and `wss://<host>` in production — no port 2567.
-
-### 3.4 Architecture Decision Records (ADRs)
-
-Any architectural decision with lasting impact must be documented as an ADR:
-
-```
-docs/adr/0001-use-sveltekit-and-prisma.md
-docs/adr/0002-server-authoritative-game-state.md
-```
+Use `docs/adr/adr-template.md` for new ADRs.
 
 ### 3.5 Anti-patterns
 
@@ -405,7 +380,7 @@ Every workflow:
 
 | Branch prefix          | CI on push                  |
 | ---------------------- | --------------------------- |
-| `feat`, `fix`, `chore` | Lint, typecheck, unit tests |
+| `feat`, `fix`, `chore` | Lint, typecheck             |
 | `ci`, `infra`          | Docker build                |
 | All other prefixes     | Full CI on PR to `main`     |
 
@@ -413,18 +388,11 @@ Full CI runs on every PR to `main`.
 
 ### 7.3 Required Status Checks (gate on `main`)
 
-| Check                      | What it runs                                          |
-| -------------------------- | ----------------------------------------------------- |
-| `ci-lint-eslint`           | `pnpm lint:eslint`                                    |
-| `ci-lint-prettier`         | `pnpm lint:prettier`                                  |
-| `ci-lint-prisma`           | `prisma format --check`                               |
-| `ci-lint-pr-title`         | Conventional Commit regex on PR title                 |
-| `ci-typecheck-frontend`    | `svelte-check`                                        |
-| `ci-typecheck-game-server` | `tsc --noEmit` (root `tsconfig.json`)                 |
-| `ci-test-unit`             | Vitest                                                |
-| `ci-test-e2e`              | Playwright (PR to `main` only)                        |
-| `ci-test-integration`      | Docker Compose stack + assertions (PR to `main` only) |
-| `ci-docker-build`          | Build Dockerfile via `compose.yaml` (no push)         |
+The full list of 6 checks and what they run is in [architecture.md](architecture.md#cicd). Key points:
+
+- **All checks are independently visible and re-runnable** in the GitHub Actions UI
+- **`ci-typecheck-game-server`** is a single workflow that runs both `svelte-check` and `tsc --noEmit` (unified typecheck)
+- `ci-docs-deploy` deploys the Docusaurus site to GitHub Pages on push to `main` (when docs/docusaurus files change)
 
 ### 7.4 Automation Workflows
 
@@ -440,7 +408,7 @@ Full CI runs on every PR to `main`.
 
 ### 7.5 Post-Merge Deployment
 
-`ci-docker-push.yaml` triggers on push to `main` only. It builds and pushes Docker images to the registry. This runs post-merge — it is not a gate.
+Docker images are built and pushed to the registry on push to `main`. This runs post-merge — it is not a gate.
 
 ---
 
@@ -501,9 +469,9 @@ clampExpiry(duration, MAX_TOKEN_EXPIRY_MS);
 
 | File                             | Purpose                                              |
 | -------------------------------- | ---------------------------------------------------- |
-| `README.md`                      | Project description, setup instructions, stack, team |
+| `README.md`                      | Project description, setup instructions, stack, links |
+| `docs/architecture.md`           | High-level architecture, file trees, scope map, hook chain |
 | `docs/engineering-guidelines.md` | This file                                            |
-| `docs/architecture.md`           | High-level architecture, diagrams                    |
 | `docs/runbook.md`                | Operational procedures                               |
 | `docs/adr/`                      | Architecture Decision Records                        |
 | `CHANGELOG.md`                   | Notable changes per release                          |
@@ -544,7 +512,6 @@ This file is a living document. When a convention changes, open a `docs(infra): 
 | Editor  | Extensions                                                              |
 | ------- | ----------------------------------------------------------------------- |
 | VS Code | Svelte for VS Code, ESLint, Prettier, Tailwind CSS IntelliSense, Prisma |
-| Any     | EditorConfig support (respect `.editorconfig`)                          |
 
 Shared settings should be committed to `.vscode/settings.json` for consistent behavior across the team.
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -21,7 +21,10 @@
 ## 1. Bootstrap — First Time Only
 
 ```bash
-git clone <repo-url> && cd ft-transcendence
+git clone <repo-url> && cd transcendance
+
+# System dependencies (required for better-sqlite3)
+sudo apt install build-essential python3
 
 pnpm install
 
@@ -48,7 +51,7 @@ docker compose down         # stop, keep volumes
 docker compose down -v      # stop and wipe volumes (destroys local DB)
 ```
 
-> Docker exposes a single port: **3000**. SvelteKit and Colyseus share the same process and the same port.
+> Docker exposes the app on port 3000 internally. Caddy acts as a reverse proxy on port 4443 with automatic TLS. Access the app at `https://localhost:4443`.
 
 ### Without Docker (dev mode)
 
@@ -121,47 +124,14 @@ pnpm lint:prisma        # see drift
 prisma format           # auto-fix, then commit
 ```
 
-### `ci-lint-pr-title`
-
-Edit the PR title directly in GitHub. Format: `type(scope): description`.
-The workflow re-triggers automatically on PR edit.
-
-### `ci-typecheck-frontend`
-
-```bash
-pnpm typecheck          # svelte-check — fix every error and warning
-pnpm typecheck:watch    # re-run on file change while working
-```
-
 ### `ci-typecheck-game-server`
 
 ```bash
-pnpm typecheck          # tsc --noEmit uses the root tsconfig.json (no separate tsconfig.server.json)
+pnpm typecheck          # unified — runs both svelte-check and tsc --noEmit
+pnpm typecheck:watch    # re-run on file change while working
 ```
 
-### `ci-test-unit`
-
-```bash
-pnpm test:unit          # Vitest — output names the exact failing test and file
-```
-
-### `ci-test-integration`
-
-```bash
-pnpm test:integration   # docker compose up --build + healthcheck poll + assertions
-```
-
-Common causes:
-
-- Healthcheck not passing → `docker compose logs <service>`
-- Missing CI secret → verify the value exists in Settings → Secrets → Actions
-- Schema out of sync → `pnpm db:migrate` locally, commit the migration file
-
-### `ci-test-e2e`
-
-```bash
-pnpm test:e2e           # Playwright — requires the full stack to be running
-```
+Both frontend and Colyseus server code are checked in a single pass using the root `tsconfig.json`.
 
 ### `ci-docker-build`
 


### PR DESCRIPTION
Closes #249

## What
Complete documentation refresh — every doc file cross-referenced against `src/`, `compose.yaml`, `.github/workflows/`, and `prisma/schema.prisma`.

## Changes

### README.md (rewritten)
- Stack table with all technologies and versions
- Quickstart for Docker (`make`) and bare metal (`pnpm`)
- Full project file tree
- Links to all docs and CHANGELOG
- Contributing summary

### docs/architecture.md (fixed)
- `server.ts` → `index.ts` (actual production entrypoint)
- Complete game server file tree (handlers, StatusRoom, statusHub, messageSchemas, validateMessage, StatusRoomState)
- Hook chain documentation (handleColyseus → handleParaglide → handleBetterAuth → handleRouteProtection)
- Room type names fixed (`tank_room` not `tankroom`, `status` room added)
- Caddy/Docker stack documented (port 4443, TLS, entrypoint)
- CI: 6 checks (was 10 — reflects PR #262 removing test/lint-pr-title workflows)

### docs/engineering-guidelines.md (deduplicated)
- Removed stack table, scope map, game tree (→ link to architecture.md)
- Fixed ADR filenames to match actual files (adr-001 through adr-009)
- Fixed `packages/game-shared` → `src/lib/game/shared`
- Fixed CI check count (6, not 10) and workflow names
- Dropped `.editorconfig` reference (no file exists)
- Updated required documents list

### docs/runbook.md (fixed)
- `ft-transcendence` → `transcendance`
- Added system dependencies (build-essential, python3) for better-sqlite3
- Merged typecheck CI sections (unified workflow)
- Removed CI failure sections for deleted workflows (ci-test-unit/e2e/integration, ci-lint-pr-title)
- Caddy port 4443 documented

### CHANGELOG.md (new)
- Full project history from 130 commits and 116 closed PRs
- Organized by category: Infra, Auth, Frontend, Game, Backend, Shared, DX

## Checklist
- [x] Documentation only — no code changes
- [x] All claims verified against src/ files
- [x] CI check names match `.github/workflows/` filenames and YAML `name` fields
- [x] No duplicate content across architecture.md and engineering-guidelines.md