### PR TITLE
fix: prevent presence desync on locale change

### DIFF
--- a/src/lib/components/FriendList.svelte
+++ b/src/lib/components/FriendList.svelte
@@ -34,11 +34,11 @@
 
 	let showAddFriend = $state(false);
 
-	let disconnect = () => {};
+	let disconnect: (() => void | Promise<void>) = () => {};
 	onMount(() => {
 		connectStatusRoom()
 			.then((fn) => {
-				disconnect = fn;
+				disconnect = fn!;
 			})
 			.catch((e) => {
 				console.error(e);

--- a/src/lib/components/FriendList.svelte
+++ b/src/lib/components/FriendList.svelte
@@ -34,7 +34,7 @@
 
 	let showAddFriend = $state(false);
 
-	let disconnect: (() => void | Promise<void>) = () => {};
+	let disconnect: () => void | Promise<void> = () => {};
 	onMount(() => {
 		connectStatusRoom()
 			.then((fn) => {
@@ -54,7 +54,7 @@
 		document.addEventListener('click', handleClickOutside, true);
 
 		return () => {
-			disconnect();
+			void disconnect();
 			document.removeEventListener('click', handleClickOutside, true);
 		};
 	});

--- a/src/lib/status-client.ts
+++ b/src/lib/status-client.ts
@@ -7,15 +7,17 @@ import { attachNotificationListeners } from './notification-client';
 
 export const presenceById = writable<Record<string, boolean>>({});
 
+let connected = false;
 let roomLeave: (() => Promise<void> | void) | null = null;
 let disconnecting = false;
 
 export async function connectStatusRoom() {
 	if (!browser) return () => {};
 	if (disconnecting) return () => {};
-	if (roomLeave) return roomLeave;
+	if (connected) return roomLeave;
 
 	const room = await colyseusClient!.joinOrCreate<StatusState>('status');
+	connected = true;
 	attachNotificationListeners(room);
 	const cb = Callbacks.get(room);
 	const stops = new Map<string, () => void>();
@@ -42,6 +44,7 @@ export async function connectStatusRoom() {
 	});
 
 	roomLeave = async () => {
+		connected = false;
 		for (const stop of stops.values()) stop();
 		stops.clear();
 		presenceById.set({});


### PR DESCRIPTION
## What

Fixes a race condition where friend presence status goes stale after changing locale. The Colyseus status room connection was silently lost when the `{#key getReactiveLocale()}` block in the layout destroyed and recreated the FriendList component.

Closes #228

## How

The root cause was `connectStatusRoom()` using module-level `roomLeave` as both the connection guard and the cleanup function. When locale changed:
1. Old cleanup fired (async) — cleared presence, started `await room.leave()`
2. `roomLeave` stayed non-null during the async gap
3. New `connectStatusRoom()` call saw `roomLeave` was still set → returned early without reconnecting

Fix: added a synchronous `connected` boolean flag that is:
- Set to `true` after joining the Colyseus room
- Set to `false` at the **top** of the cleanup function (before `await room.leave()`, so it runs synchronously)
- Used as the reconnection guard instead of `roomLeave`

Also fixed a pre-existing TypeScript error where `disconnect` in FriendList was inferred too narrowly for `connectStatusRoom()`'s actual return type.

## Checklist
- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No unintended side effects