### PR TITLE
fix: matchmaking cancel deadlock on opponent disconnect

### DIFF
--- a/src/lib/components/GameLobby.svelte
+++ b/src/lib/components/GameLobby.svelte
@@ -5,6 +5,7 @@
 	import Avatar from '$lib/components/Avatar.svelte';
 	import { LoaderCircle } from '@lucide/svelte';
 	import { resolve } from '$app/paths';
+	import { goto } from '$app/navigation';
 	import { m } from '$lib/paraglide/messages';
 
 	let { room, user }: { room: Room<GameRoomState>; user: User } = $props();
@@ -12,6 +13,8 @@
 	let opponent = $state<{ name: string; image: string | null } | null>(null);
 	let readySent = $state(false);
 	let countdown = $state(3);
+	let reconnecting = $state(false);
+	let reconnectCountdown = $state(10);
 
 	const isPlayer0 = $derived(room.sessionId === room.state.player0Id);
 
@@ -23,6 +26,12 @@
 					name: isPlayer0 ? state.player1Name : state.player0Name,
 					image: (isPlayer0 ? state.player1Image : state.player0Image) || null
 				};
+			} else if ((!state.player0Id || !state.player1Id) && opponent) {
+				opponent = null;
+				readySent = false;
+				countdown = 3;
+				reconnecting = true;
+				reconnectCountdown = 10;
 			}
 		};
 		room.onStateChange(handler);
@@ -36,6 +45,19 @@
 			if (countdown <= 0) {
 				clearInterval(interval);
 				room.send('ready');
+			}
+		}, 1000);
+		return () => clearInterval(interval);
+	});
+
+	$effect(() => {
+		if (!reconnecting) return;
+		const interval = setInterval(() => {
+			reconnectCountdown -= 1;
+			if (reconnectCountdown <= 0) {
+				clearInterval(interval);
+				room.send('ready');
+				void goto(resolve('/game'));
 			}
 		}, 1000);
 		return () => clearInterval(interval);

--- a/src/lib/game/colyseus/TankRoom.ts
+++ b/src/lib/game/colyseus/TankRoom.ts
@@ -160,6 +160,20 @@ export class TankRoom extends Room<{ state: GameRoomState }> {
 		const idx = this.getPlayerIndex(client);
 		if (idx !== undefined && this.playerIds[idx]) activePlayers.delete(this.playerIds[idx]);
 
+		if (!this.gameStarted) {
+			if (idx === 0) {
+				this.state.player0Id = '';
+				this.state.player0Name = '';
+				this.state.player0Image = '';
+			} else if (idx === 1) {
+				this.state.player1Id = '';
+				this.state.player1Name = '';
+				this.state.player1Image = '';
+			}
+			this.playersReady = [false, false];
+			return;
+		}
+
 		if (this.physicsState && this.physicsState.phase !== 'OVER') {
 			const winner = (idx === 0 ? 1 : 0) satisfies 0 | 1;
 			this.physicsState.phase = 'OVER';


### PR DESCRIPTION
## What

Fixes the matchmaking deadlock where one player gets stuck forever on the "Starting in…" spinner when the opponent disconnects during the lobby countdown.

Closes #230

## How

Two-part fix:

**Server-side** (`TankRoom.ts`): `onLeave` now handles pre-game disconnects. When a player leaves before `initGame()`, their slot (`state.player0Id`/`player1Id`) is cleared and `playersReady` is reset. Previously `onLeave` only handled in-game forfeits — pre-game disconnects were silently ignored, leaving a ghost player in the room state.

**Client-side** (`GameLobby.svelte`): `onStateChange` now detects when the opponent's slot becomes empty and resets to searching state. A 10-second re-queue countdown starts (matching the server's `allowReconnection` window), then the client leaves the zombie room and navigates to `/game` for a fresh `joinOrCreate`.

## Checklist
- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No unintended side effects