### PR TITLE
fix: error handling normalization and shader condition

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -25,7 +25,7 @@
 		page.url.pathname.startsWith('/login') || page.url.pathname.startsWith('/register')
 	);
 
-	const isError = $derived(page.status > 400);
+	const isError = $derived(page.status >= 400 && !!page.error);
 	const baseTheme = $derived($shaderTheme === 'dark');
 </script>
 

--- a/src/routes/game/[[id]]/client.ts
+++ b/src/routes/game/[[id]]/client.ts
@@ -38,7 +38,7 @@ const handleMatchMakeError = (err: MatchMakeError) => {
 	} else {
 		message = err.message;
 	}
-	return { status: err.code, error: { message: message } };
+	return { status: err.code >= 100 && err.code < 600 ? err.code : 400, error: { message } };
 };
 
 export const connectToRoom = async (roomId?: string) => {

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -48,10 +48,18 @@ export const actions: Actions = {
 		if (!form.valid) {
 			return fail(400, { form });
 		}
-		await auth.api.updateUser({
-			body: { name: form.data.name },
-			headers: request.headers
-		});
+		try {
+			await auth.api.updateUser({
+				body: { name: form.data.name },
+				headers: request.headers
+			});
+		} catch (error: unknown) {
+			const body = (error as { body?: { message?: string } })?.body;
+			if (body?.message?.includes('Unique constraint')) {
+				return setError(form, 'name', 'This name is already taken');
+			}
+			return setError(form, 'name', m.error_generic());
+		}
 		return message(form, 'Updated Name');
 	},
 	changePassword: async ({ request }) => {


### PR DESCRIPTION
## What

Fixes three error-handling issues: Colyseus internal error codes rendering as raw numbers on the error page, the red error shader not activating for status 400 errors, and an unhandled Prisma unique-constraint crash when changing to an existing username.

Closes #235

## How

**Colyseus error code normalization** (`client.ts`): `handleMatchMakeError` now clamps Colyseus error codes (4001, 6000+, etc.) to valid HTTP range (100-599). Unknown codes fall back to 400 so the error page shows a recognizable status.

**Shader condition** (`+layout.svelte`): changed `page.status > 400` to `page.status >= 400 && !!page.error`. This activates the red ember shader for all real errors (including status 400 from disposed-room / already-in-game) while keeping it off for form validation errors where `page.error` is null.

**Name change crash** (`settings/+page.server.ts`): added try/catch around `auth.api.updateUser` in the `changeName` action. Catches Prisma P2002 unique-constraint errors when the new name is already taken and returns an inline form error instead of crashing to 500.

## Checklist
- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [x] No unintended side effects