### PR TITLE
feat(secutity): Harden registration path

### DIFF
--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,11 +1,22 @@
-import { betterAuth } from 'better-auth';
 import { prismaAdapter } from 'better-auth/adapters/prisma';
+import { betterAuth, } from 'better-auth';
+import { createAuthMiddleware, APIError } from "better-auth/api";
 import db from '$lib/server/db';
 import { sveltekitCookies } from 'better-auth/svelte-kit';
 import { getRequestEvent } from '$app/server';
 import { env } from '$env/dynamic/private';
 import { building } from '$app/environment';
 import { twoFactor } from 'better-auth/plugins';
+
+const NAME_REGEX = /^[a-zA-Z0-9_-]+$/;
+
+function validateName(name: string) {
+	if (!name || name.length < 3 || name.length > 32 || !NAME_REGEX.test(name)) {
+		throw new APIError('BAD_REQUEST', {
+			message: 'Invalid name: must be 3-32 characters, only letters, numbers, _ and -'
+		});
+	}
+}
 
 export const auth = betterAuth({
 	database: prismaAdapter(db, {
@@ -18,6 +29,19 @@ export const auth = betterAuth({
 	},
 	experimental: { joins: true },
 	emailAndPassword: { enabled: true },
+	hooks: {
+		before: createAuthMiddleware(async (ctx) => {
+			const isSignUp = ctx.path === '/sign-up/email';
+			const isUpdate = ctx.path === '/update-user';
+
+			if (!isSignUp && !isUpdate) return;
+
+			const name = ctx.body?.name;
+			if (name !== undefined) {
+				validateName(name);
+			}
+		})
+	},
 	plugins: [
 		twoFactor({
 			issuer: 'ft_transcendence',

--- a/src/lib/server/auth.ts
+++ b/src/lib/server/auth.ts
@@ -1,6 +1,6 @@
 import { prismaAdapter } from 'better-auth/adapters/prisma';
-import { betterAuth, } from 'better-auth';
-import { createAuthMiddleware, APIError } from "better-auth/api";
+import { betterAuth } from 'better-auth';
+import { createAuthMiddleware, APIError } from 'better-auth/api';
 import db from '$lib/server/db';
 import { sveltekitCookies } from 'better-auth/svelte-kit';
 import { getRequestEvent } from '$app/server';
@@ -36,10 +36,12 @@ export const auth = betterAuth({
 
 			if (!isSignUp && !isUpdate) return;
 
-			const name = ctx.body?.name;
-			if (name !== undefined) {
+			const body = ctx.body as Record<string, unknown> | undefined;
+			const name = body?.name;
+			if (typeof name === 'string') {
 				validateName(name);
 			}
+			return Promise.resolve();
 		})
 	},
 	plugins: [


### PR DESCRIPTION
## What

Fix the issue where we can register through API, without conforming to regex.

Closes #224 

## How

Using a hook before, that match a regex.

## Checklist

- [ ] Cannot register without conforming to regex.
