### PR TITLE
Fix/273 miscellaneous patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Multiplayer browser game — SvelteKit + Colyseus + Phaser 4.
 | Auth            | Better-Auth                                                 |
 | Database        | Prisma 7 + SQLite (better-sqlite3)                          |
 | i18n            | Paraglide JS                                                |
-| Package manager | pnpm 11.4.0                                                |
+| Package manager | pnpm 11.4.0                                                 |
 | Runtime         | Node 24.15.0                                                |
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Multiplayer browser game — SvelteKit + Colyseus + Phaser 4.
 | Auth            | Better-Auth                                                 |
 | Database        | Prisma 7 + SQLite (better-sqlite3)                          |
 | i18n            | Paraglide JS                                                |
-| Package manager | pnpm 10.33.0                                                |
+| Package manager | pnpm 11.4.0                                                |
 | Runtime         | Node 24.15.0                                                |
 
 ## Quickstart

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@ SvelteKit + Colyseus + Prisma monorepo for a multiplayer browser game.
 | Auth            | Better-Auth                                                     |
 | Database        | Prisma 7 + SQLite (better-sqlite3)                              |
 | i18n            | Paraglide JS                                                    |
-| Package manager | pnpm 10.33.0                                                    |
+| Package manager | pnpm 11.4.0                                                     |
 | Runtime         | Node 24.15.0                                                    |
 
 ## Process Model
@@ -149,4 +149,4 @@ Squash-merge only. All checks must pass. 1 required approval minimum.
 
 4 automation workflows manage labels (`automation-label-issue`, `automation-label-pr`) and issue status (`automation-state-branch`, `automation-state-pr`).
 
-See [engineering-guidelines.md](engineering-guidelines.md) for the full workflow specification. See [docs/adr/](adr/) for the 9 Architecture Decision Records.
+See [engineering-guidelines.md](engineering-guidelines.md) for the full workflow specification. See `adr/` for the 9 Architecture Decision Records.

--- a/docs/engineering-guidelines.md
+++ b/docs/engineering-guidelines.md
@@ -503,7 +503,7 @@ This file is a living document. When a convention changes, open a `docs(infra): 
 | Tool             | Version       | Install                                   |
 | ---------------- | ------------- | ----------------------------------------- |
 | Node.js          | 24.x          | [nodejs.org](https://nodejs.org) or `nvm` |
-| pnpm             | 10.33.0       | `npm install -g pnpm@10.33.0`             |
+| pnpm             | 11.4.0        | `npm install -g pnpm@11.4.0`              |
 | Docker + Compose | Latest stable | [docker.com](https://www.docker.com)      |
 | Git              | 2.x+          | System package manager                    |
 

--- a/src/lib/components/GameLobby.svelte
+++ b/src/lib/components/GameLobby.svelte
@@ -44,7 +44,6 @@
 		}, 1000);
 		return () => clearInterval(interval);
 	});
-
 </script>
 
 <div class="flex flex-col items-center gap-10">

--- a/src/lib/components/GameLobby.svelte
+++ b/src/lib/components/GameLobby.svelte
@@ -5,7 +5,6 @@
 	import Avatar from '$lib/components/Avatar.svelte';
 	import { LoaderCircle } from '@lucide/svelte';
 	import { resolve } from '$app/paths';
-	import { goto } from '$app/navigation';
 	import { m } from '$lib/paraglide/messages';
 
 	let { room, user }: { room: Room<GameRoomState>; user: User } = $props();
@@ -13,8 +12,6 @@
 	let opponent = $state<{ name: string; image: string | null } | null>(null);
 	let readySent = $state(false);
 	let countdown = $state(3);
-	let reconnecting = $state(false);
-	let reconnectCountdown = $state(10);
 
 	const isPlayer0 = $derived(room.sessionId === room.state.player0Id);
 
@@ -30,12 +27,10 @@
 				opponent = null;
 				readySent = false;
 				countdown = 3;
-				reconnecting = true;
-				reconnectCountdown = 10;
 			}
 		};
 		room.onStateChange(handler);
-		return () => room.onStateChange.remove(handler);
+		return () => room?.onStateChange?.remove?.(handler);
 	});
 
 	$effect(() => {
@@ -50,18 +45,6 @@
 		return () => clearInterval(interval);
 	});
 
-	$effect(() => {
-		if (!reconnecting) return;
-		const interval = setInterval(() => {
-			reconnectCountdown -= 1;
-			if (reconnectCountdown <= 0) {
-				clearInterval(interval);
-				room.send('ready');
-				void goto(resolve('/game'));
-			}
-		}, 1000);
-		return () => clearInterval(interval);
-	});
 </script>
 
 <div class="flex flex-col items-center gap-10">

--- a/src/lib/game/colyseus/TankRoom.ts
+++ b/src/lib/game/colyseus/TankRoom.ts
@@ -191,8 +191,8 @@ export class TankRoom extends Room<{ state: GameRoomState }> {
 	}
 
 	onDrop(client: Client) {
-		const idx = this.getPlayerIndex(client);
-		if (idx !== undefined && this.playerIds[idx]) activePlayers.delete(this.playerIds[idx]);
+		//const idx = this.getPlayerIndex(client);
+		//if (idx !== undefined && this.playerIds[idx]) activePlayers.delete(this.playerIds[idx]);
 		this.allowReconnection(client, 10);
 	}
 

--- a/src/routes/game/[[id]]/client.ts
+++ b/src/routes/game/[[id]]/client.ts
@@ -38,7 +38,7 @@ const handleMatchMakeError = (err: MatchMakeError) => {
 	} else {
 		message = err.message;
 	}
-	return { status: err.code >= 100 && err.code < 600 ? err.code : 400, error: { message } };
+	return { status: 404, error: { message } };
 };
 
 export const connectToRoom = async (roomId?: string) => {

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -43,8 +43,7 @@ export const actions: Actions = {
 				body: { image: `/avatar/${locals.user!.id}?k=${randomInt(0, 4096)}` },
 				headers: request.headers
 			});
-		}
-		catch {
+		} catch {
 			return setError(form, 'file', m.error_generic());
 		}
 		return message(form, 'Updated Avatar');

--- a/src/routes/settings/+page.server.ts
+++ b/src/routes/settings/+page.server.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '$lib/server/prisma/client';
 import { redirect } from '@sveltejs/kit';
 import { superValidate, setError, message, fail } from 'sveltekit-superforms';
 import { zod4 } from 'sveltekit-superforms/adapters';
@@ -34,13 +35,18 @@ export const actions: Actions = {
 		if (!form.valid) {
 			return fail(400, { form });
 		}
-		const filePath = path.join(path.resolve('static/uploads'), locals.user!.id);
-		const buffer = Buffer.from(await form.data.file.arrayBuffer());
-		await writeFile(filePath, buffer);
-		await auth.api.updateUser({
-			body: { image: `/avatar/${locals.user!.id}?k=${randomInt(0, 4096)}` },
-			headers: request.headers
-		});
+		try {
+			const filePath = path.join(path.resolve('static/uploads'), locals.user!.id);
+			const buffer = Buffer.from(await form.data.file.arrayBuffer());
+			await writeFile(filePath, buffer);
+			await auth.api.updateUser({
+				body: { image: `/avatar/${locals.user!.id}?k=${randomInt(0, 4096)}` },
+				headers: request.headers
+			});
+		}
+		catch {
+			return setError(form, 'file', m.error_generic());
+		}
 		return message(form, 'Updated Avatar');
 	},
 	changeName: async ({ request }) => {
@@ -54,9 +60,8 @@ export const actions: Actions = {
 				headers: request.headers
 			});
 		} catch (error: unknown) {
-			const body = (error as { body?: { message?: string } })?.body;
-			if (body?.message?.includes('Unique constraint')) {
-				return setError(form, 'name', 'This name is already taken');
+			if (error instanceof Prisma.PrismaClientKnownRequestError && error.code == 'P2002') {
+				return setError(form, 'name', m.error_username_taken());
 			}
 			return setError(form, 'name', m.error_generic());
 		}


### PR DESCRIPTION
## What

Addresses a handful of independent bugs and minor improvements across reconnection handling, error management, and tooling.

Closes #273

## How

**Reconnection (`GameLobby.svelte`, `TankRoom.ts`)**
Colyseus's `allowReconnection` requires the player seat to remain intact during the grace window, but `onDrop` was immediately calling `activePlayers.delete`, invalidating it. Commented that out. The redundant client-side countdown (which was auto-sending `ready` and calling `goto` regardless of actual reconnection state) was also removed entirely. Tightened the `onStateChange` cleanup with optional chaining to avoid teardown errors.

**Matchmake error status (`client.ts`)**
The previous logic forwarded the raw Colyseus error code as an HTTP status, which could produce invalid or misleading responses. Hardcoded to `404` — the only meaningful signal here is that no room was found.

**Settings page (`+page.server.ts`)**
- Wrapped the avatar upload + `updateUser` call in a `try/catch` to prevent unhandled throws surfacing as 500s.
- Replaced the brittle `body.message.includes('Unique constraint')` string check with a typed `Prisma.PrismaClientKnownRequestError` + `P2002` error code check.

**Tooling**
Bumped pnpm from `10.33.0` → `11.4.0` across all doc references. Fixed a broken relative link to the ADR directory in `architecture.md`.

> **Reviewer note:** the `activePlayers.delete` lines in `TankRoom.ts` are currently commented out rather than removed — worth discussing whether they should be deleted entirely or if there's a future use case for them.

## Checklist
- [ ] Tests added or updated
- [ ] Documentation updated if needed
- [ ] No unintended side effects