### PR TITLE
feat(back): Notify other friend when delete account

### DIFF
--- a/src/lib/friends.remote.ts
+++ b/src/lib/friends.remote.ts
@@ -91,3 +91,14 @@ export const send = form(z.strictObject({ email: z.email() }), async ({ email },
 	await sendOrAccept(locals.user, other);
 	void list().refresh();
 });
+
+export const notifyRemoval = command(z.void(), async () => {
+	const { locals } = getRequestEvent();
+	if (!locals.user) return;
+
+	const friends = await getFriendList(locals.user.id);
+
+	for (const friend of friends) {
+		await dismissOrRemove(locals.user, friend);
+	}
+});

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -18,6 +18,7 @@
 	import { resolve } from '$app/paths';
 	import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js';
 	import { authClient } from '$lib/auth-client';
+	import * as friends from '$lib/friends.remote';
 
 	let { data }: PageProps = $props();
 
@@ -75,7 +76,9 @@
 	let fileInput: HTMLInputElement;
 	let nameFormEl: HTMLFormElement | undefined = $state();
 	let editing = $state(false);
+
 	async function handleDelete() {
+		await friends.notifyRemoval();
 		await authClient.deleteUser();
 		await goto(resolve('/register'), { invalidateAll: true });
 	}


### PR DESCRIPTION
## What

When we delete our account, the friend are removed FIRST (with notification), THEN delete account.

Closes #239 

## How

Added a func to remove all friends.

## Checklist

- [ ] Work for friends
- [ ] Work for pending friends request (user -> friend)
- [ ] Work for pending friends request (friend -> user)