### PR TITLE
fix(game): solve the reconnection in lobby error

### DIFF
--- a/src/lib/game/colyseus/TankRoom.ts
+++ b/src/lib/game/colyseus/TankRoom.ts
@@ -135,7 +135,7 @@ export class TankRoom extends Room<{ state: GameRoomState }> {
 		_options: unknown,
 		user: { id: string; name: string; image?: string | null }
 	) {
-		const idx = this.clients.length - 1;
+		const idx = this.state.player0Id === '' ? 0 : 1;
 		activePlayers.add(user.id);
 		console.log(`[TankRoom] onJoin — idx=${idx}, sessionId=${client.sessionId}`);
 		if (idx === 0) {


### PR DESCRIPTION
## What

An issue occurred when reconnecting, inside the lobby room, when two players previously where connected, if player 0 disconnect and reconnects, it would override and delete the other player. Causing an awkward situation where both players are in the room waiting.

Closes #278

## How

Fix the broken code logic for determining index from users in the room.

## Checklist

- [ ] No unintended side effects
