### PR TITLE
fix(game): firefox console log error 0 fix

### DIFF
--- a/src/lib/game/phaser/game.ts
+++ b/src/lib/game/phaser/game.ts
@@ -1,3 +1,4 @@
+import './patchTextShadow';
 import GameScene from './scenes/gameScene/GameScene';
 import { Game } from 'phaser';
 import type { Room } from '@colyseus/sdk';

--- a/src/lib/game/phaser/lobbyGame.ts
+++ b/src/lib/game/phaser/lobbyGame.ts
@@ -1,3 +1,4 @@
+import './patchTextShadow';
 import DemoScene from './scenes/demoScene';
 import { commonGameConfig } from './commonGameConfig';
 import { Game } from 'phaser';

--- a/src/lib/game/phaser/patchTextShadow.ts
+++ b/src/lib/game/phaser/patchTextShadow.ts
@@ -1,0 +1,26 @@
+import { GameObjects } from 'phaser';
+
+interface ShadowStyle {
+	shadowOffsetX: number;
+	shadowOffsetY: number;
+	shadowColor: string;
+	shadowBlur: number;
+}
+
+const proto = GameObjects.TextStyle.prototype as unknown as {
+	syncShadow(this: ShadowStyle, context: CanvasRenderingContext2D, enabled: boolean): void;
+};
+
+proto.syncShadow = function (context, enabled) {
+	if (enabled) {
+		context.shadowOffsetX = this.shadowOffsetX;
+		context.shadowOffsetY = this.shadowOffsetY;
+		context.shadowColor = this.shadowColor;
+		context.shadowBlur = this.shadowBlur;
+	} else {
+		context.shadowOffsetX = 0;
+		context.shadowOffsetY = 0;
+		context.shadowColor = 'rgba(0,0,0,0)';
+		context.shadowBlur = 0;
+	}
+};


### PR DESCRIPTION
## What

Every time your game drew text (the tank name labels like "Red"/"Blue", and all the in-game HUD text), Firefox printed a warning in the console: "Expected color but found '0'." It showed up on the homepage and in the real game, but never on the settings page.

Closes #280 

## How

TextStyle.syncShadow() assigns `context.shadowColor = 0`
This triggers firefox logs with `Expected color but found '0'`    (Chrome ignores it).

So instead of letting Phaser decide what to give the browser, since shadow was not set, we replace the method with a valid transparent color and we import it before any Game/Text is created.

## Checklist

- [ ] No unintended side effects
