### PR TITLE
Security/294 exception handling in rooms

### DIFF
--- a/src/lib/game/colyseus/TankRoom.ts
+++ b/src/lib/game/colyseus/TankRoom.ts
@@ -1,10 +1,4 @@
-import {
-	Room,
-	type Client,
-	ServerError,
-	type RoomException,
-	type RoomMethodName
-} from 'colyseus';
+import { Room, type Client, ServerError, type RoomException, type RoomMethodName } from 'colyseus';
 import { auth } from '$lib/server/auth';
 import { GameRoomState } from '$lib/game/colyseus/schema/GameRoomState';
 import { generateTerrain, getHeightAt, applyCrater } from '$lib/game/shared/logic/terrain';

--- a/src/lib/game/colyseus/TankRoom.ts
+++ b/src/lib/game/colyseus/TankRoom.ts
@@ -1,4 +1,10 @@
-import { Room, type Client, ServerError } from 'colyseus';
+import {
+	Room,
+	type Client,
+	ServerError,
+	type RoomException,
+	type RoomMethodName
+} from 'colyseus';
 import { auth } from '$lib/server/auth';
 import { GameRoomState } from '$lib/game/colyseus/schema/GameRoomState';
 import { generateTerrain, getHeightAt, applyCrater } from '$lib/game/shared/logic/terrain';
@@ -97,6 +103,7 @@ export class TankRoom extends Room<{ state: GameRoomState }> {
 		this.onMessage(
 			'select_weapon',
 			validated(SelectWeaponSchema, (client, data) => {
+				// TEMP: crash test — remove this line.
 				if (!this.isCurrentPlayer(client)) return;
 				if (this.physicsState?.phase !== 'AIMING') return;
 				const p = this.physicsState.currentPlayer;
@@ -215,6 +222,11 @@ export class TankRoom extends Room<{ state: GameRoomState }> {
 
 	onDispose() {
 		this.log('dispose room');
+	}
+
+	onUncaughtException(err: RoomException, methodName: RoomMethodName) {
+		this.error(`uncaught exception in ${methodName}:`, err.cause ?? err);
+		void this.disconnect();
 	}
 
 	private sendGameStartOnReconnect(client: Client) {

--- a/src/lib/game/colyseus/TankRoom.ts
+++ b/src/lib/game/colyseus/TankRoom.ts
@@ -97,7 +97,6 @@ export class TankRoom extends Room<{ state: GameRoomState }> {
 		this.onMessage(
 			'select_weapon',
 			validated(SelectWeaponSchema, (client, data) => {
-				// TEMP: crash test — remove this line.
 				if (!this.isCurrentPlayer(client)) return;
 				if (this.physicsState?.phase !== 'AIMING') return;
 				const p = this.physicsState.currentPlayer;


### PR DESCRIPTION
## What

Before if any room callback threw an uncaught exception, the error propagated up to Node's event loop and crashed the entire process.
Now the error is contained in the room where the error occured, disconnecting both players from the game and leaving the server and every other room intact.

Closes #294 

## How

added an onUncaughtException handler to TankRoom so an uncaught error in the game room no longer crashes the whole server.

see https://docs.colyseus.io/room/exception-handling

## Checklist

- [ ] No unintended side effects
